### PR TITLE
Add start and dev scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ test = {shell = "docker compose up --build --abort-on-container-exit" }
 precommit = { shell = "pre-commit run --all-files" }
 all = { composite = ["format", "lint", "test"] }
 
+start = { cmd = "uvicorn src.mainframe.server:app" }
+dev = { cmd = "uvicorn src.mainframe.server:app --reload" }
+
 [tool.isort]
 profile = "black"
 


### PR DESCRIPTION
Adds 2 convenient PDM scripts:
- `pdm run`: executes `uvicorn src.mainframe.server:app`
- `pdm dev`: executes `uvicorn src.mainframe.server:app --reload`