### PR TITLE
Lock db during `get_job`

### DIFF
--- a/src/mainframe/endpoints/job.py
+++ b/src/mainframe/endpoints/job.py
@@ -22,6 +22,7 @@ async def get_job(session: Annotated[AsyncSession, Depends(get_db)], request: Re
         .where(Package.status == Status.QUEUED)
         .order_by(Package.queued_at)
         .options(selectinload(Package.download_urls))
+        .with_for_update()
     )
     package = scalars.first()
 


### PR DESCRIPTION
This makes sure multiple requests are not getting the same release to scan.

Thanks Robin~

Closes #49 