### PR TITLE
Add GIT_SHA to Dockerfile for Sentry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ CMD ["pdm", "run", "pytest", "tests", "-vv"]
 
 FROM python:3.11-slim@sha256:53a67c012da3b807905559fa59fac48a3a68600d73c5da10c2f0d8adc96dbd01 as prod
 
+# Define Git SHA build argument for sentry
+ARG git_sha="development"
+ENV GIT_SHA=$git_sha
+
 ENV PYTHONPATH=/app/pkgs
 WORKDIR /app
 COPY --from=builder /app/__pypackages__/3.11/lib pkgs/


### PR DESCRIPTION
The [upstream workflow](https://github.com/darbiadev/.github/blob/44a991d8ab123fbc370aa7aaae25907f38f4fc1b/.github/workflows/docker-build-push.yaml#L65-L66) already passes this arg in.