### PR TITLE
Patched logging to always pretty-print to avoid current infra crashing

### DIFF
--- a/src/mainframe/server.py
+++ b/src/mainframe/server.py
@@ -68,13 +68,17 @@ def configure_logger():
         cache_logger_on_first_use=True,
     )
 
-    log_renderer: structlog.types.Processor
-    # If running in production, render logs with JSON.
-    if mainframe_settings.production:
-        log_renderer = structlog.processors.JSONRenderer()
-    else:
-        # If running in a development environment, pretty print logs
-        log_renderer = structlog.dev.ConsoleRenderer()
+    # log_renderer: structlog.types.Processor
+    # # If running in production, render logs with JSON.
+    # if mainframe_settings.production:
+    #     log_renderer = structlog.processors.JSONRenderer()
+    # else:
+    #     # If running in a development environment, pretty print logs
+    #     log_renderer = structlog.dev.ConsoleRenderer()
+
+    # TODO: Once infra for log aggregation is up and running, remove this and go back to
+    # TODO: JSON logging in production.
+    log_renderer = structlog.dev.ConsoleRenderer()
 
     formatter = structlog.stdlib.ProcessorFormatter(
         foreign_pre_chain=shared_processors,


### PR DESCRIPTION
JSON logging breaks infra, until we can get loki or something set up, this patch will default logs to pretty-print.