### PR TITLE
Fix bug where rules were not going into DB 

### DIFF
--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -66,7 +66,7 @@ async def submit_results(
     scan.commit_hash = result.commit
 
     # These are the rules that already have an entry in the database
-    rules = await session.scalars(select(Rule).where(Rule.name.in_(result.rules_matched)))
+    rules = (await session.scalars(select(Rule).where(Rule.name.in_(result.rules_matched)))).all()
     rule_names = {rule.name for rule in rules}
     scan.rules.extend(rules)
 


### PR DESCRIPTION
Closes #80 

Apparently `ScalarResult` objects are exhaustible iterators, and the `{rule.name for rule in rules}` line was exhausting it before it could be added into the database. Using `.all()` converts the `ScalarResult[T]` into `Sequence[T]`