### PR TITLE
Bump SQLAlchemy pool size to 25

### DIFF
--- a/src/mainframe/database.py
+++ b/src/mainframe/database.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from mainframe.constants import mainframe_settings
 
-engine = create_async_engine(mainframe_settings.db_url)
+engine = create_async_engine(mainframe_settings.db_url, pool_size=25)
 async_session = async_sessionmaker(bind=engine, expire_on_commit=False)
 
 


### PR DESCRIPTION
Bump the SQLAlchemy connection pool size to 25. The default is 5 and I think this might be too low for our usecase, since we're seeing a lot of pool size exceeded type errors in kubernetes.