### PR TITLE
Use SQLAlchemy's bulk insert for batch package

### DIFF
--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from letsbuilda.pypi.async_client import PyPIServices  # type: ignore
 from letsbuilda.pypi.exceptions import PackageNotFoundError
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -203,13 +204,8 @@ async def batch_queue_package(
 
         rows.append(scan)
 
-    async with session.begin():
-        for row in rows:
-            try:
-                async with session.begin_nested():
-                    session.add(row)
-            except IntegrityError:
-                pass
+    await session.execute(insert(Scan).values(rows).on_conflict_do_nothing())
+    await session.commit()
 
 
 @router.post(


### PR DESCRIPTION
We've been seeing some issues with queries hanging and timing out - further debugging reveals that it might have to do with how we're using transactions and savepoints. Using SQLAlchemy's bulk `insert` should hopefully alleviate that problem.