### PR TITLE
Place GET /package behind auth

### DIFF
--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -103,7 +103,11 @@ async def submit_results(
     await session.commit()
 
 
-@router.get("/package", responses={400: {"model": Error, "description": "Invalid parameter combination."}})
+@router.get(
+    "/package",
+    responses={400: {"model": Error, "description": "Invalid parameter combination."}},
+    dependencies=[Depends(validate_token)],
+)
 async def lookup_package_info(
     session: Annotated[AsyncSession, Depends(get_db)],
     since: Optional[int] = None,


### PR DESCRIPTION
Closes #121 

Place the `GET /package` (`lookup_package_info` function) behind authentication by adding `validate_token` as a dependency. We don't actually are about the actual credentials, only that it's valid, so it's in the path operation decorator instead of as a function argument.