### PR TITLE
Make `MICROSOFT_*` credentials optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,9 +147,9 @@ You'll need to have the following environment variables set.
 | `SENTRY_ENVIRONMENT` | str | "" | Sentry environment |
 | `SENTRY_RELEASE_PREFIX` | str | "" | Sentry release prefix |
 | | | | |
-| `MICROSOFT_TENANT_ID` | str | | Microsoft tenant ID for automated emails |
-| `MICROSOFT_CLIENT_ID` | str | | Microsoft client ID for automated emails |
-| `MICROSOFT_CLIENT_SECRET` | str | | Microsoft client secret for automated emails |
+| `MICROSOFT_TENANT_ID` | str | "" | Microsoft tenant ID for automated emails |
+| `MICROSOFT_CLIENT_ID` | str | "" | Microsoft client ID for automated emails |
+| `MICROSOFT_CLIENT_SECRET` | str | "" | Microsoft client secret for automated emails |
 
 **NOTE**: Environment variables where the `default` column is empty are required for the application to startup
 

--- a/src/mainframe/constants.py
+++ b/src/mainframe/constants.py
@@ -51,9 +51,9 @@ Sentry = _Sentry()  # pyright: ignore
 class Microsoft(EnvConfig):
     EnvConfig.model_config["env_prefix"] = "microsoft_"
 
-    tenant_id: str
-    client_id: str
-    client_secret: str
+    tenant_id: str = ""
+    client_id: str = ""
+    client_secret: str = ""
 
 
 microsoft_settings = Microsoft()  # pyright: ignore


### PR DESCRIPTION
`MICROSOFT_*` related environment variables should be made optional on startup, as they're only needed for the mailing functionality. 