### PR TITLE
Optimize batch queue

### DIFF
--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -176,40 +176,35 @@ def lookup_package_info(
     },
 )
 def batch_queue_package(
-    packages: list[PackageSpecifier],
+    packages_list: list[PackageSpecifier],
     session: Annotated[Session, Depends(get_db)],
     auth: Annotated[AuthenticationData, Depends(validate_token)],
     request: Request,
 ):
     pypi_client: PyPIServices = request.app.state.pypi_client
+    packages = {(s.name, s.version) for s in packages_list}
 
-    valid_packages: list[Scan] = []
-    for package in packages:
-        try:
-            package_metadata = pypi_client.get_package_metadata(package.name, package.version)
-        except PackageNotFoundError:
-            continue
-
-        scan = Scan(
-            name=package_metadata.title,
-            version=package_metadata.releases[0].version,
-            status=Status.QUEUED,
-            queued_by=auth.subject,
-            download_urls=[
-                DownloadURL(url=distribution.url) for distribution in package_metadata.releases[0].distributions
-            ],
-        )
-
-        valid_packages.append(scan)
-
-    scalars = session.scalars(
-        select(Scan).where(tuple_(Scan.name, Scan.version).in_([(s.name, s.version) for s in valid_packages]))
-    )
+    scalars = session.scalars(select(Scan).where(tuple_(Scan.name, Scan.version).in_(packages)))
 
     existing_rows = {(scan.name, scan.version) for scan in scalars.all()}
 
-    for scan in valid_packages:
-        if (scan.name, scan.version) not in existing_rows:
+    for package in packages:
+        if package not in existing_rows:
+            try:
+                package_metadata = pypi_client.get_package_metadata(*package)
+            except PackageNotFoundError:
+                continue
+
+            scan = Scan(
+                name=package_metadata.title,
+                version=package_metadata.releases[0].version,
+                status=Status.QUEUED,
+                queued_by=auth.subject,
+                download_urls=[
+                    DownloadURL(url=distribution.url) for distribution in package_metadata.releases[0].distributions
+                ],
+            )
+
             session.add(scan)
 
     session.commit()

--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -25,7 +25,7 @@ class PackageSpecifier(BaseModel):
     """
 
     name: str
-    version: Optional[str]
+    version: str
 
     class Config:
         frozen = True


### PR DESCRIPTION
Optimize the batch queue endpoint so that we deduplicate *before* fetching package metadata from PyPI. This should result in a drastic performance increase from before, where we were sending 100 requests to PyPI every minute.