### PR TITLE
Patch optimize batch queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN pdm install -d
 
 COPY tests/ tests/
 ENV env=test
+ENV GIT_SHA="testing"
 
 CMD ["pdm", "run", "pytest", "tests", "-vv"]
 

--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -187,7 +187,7 @@ def batch_queue_package(
 
     scalars = session.scalars(select(Scan).where(tuple_(Scan.name, Scan.version).in_(name_ver)))
 
-    packages_to_check = {(scan.name, scan.version) for scan in scalars.all()} - name_ver
+    packages_to_check = name_ver - {(scan.name, scan.version) for scan in scalars.all()}
 
     for package in packages_to_check:
         try:

--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -191,7 +191,7 @@ def batch_queue_package(
 
     for package in packages_to_check:
         try:
-            package_metadata = pypi_client.get_package_metadata(package.name, package.version)
+            package_metadata = pypi_client.get_package_metadata(*package)
         except PackageNotFoundError:
             continue
 
@@ -205,17 +205,7 @@ def batch_queue_package(
             ],
         )
 
-        valid_packages.append(scan)
-
-    scalars = session.scalars(
-        select(Scan).where(tuple_(Scan.name, Scan.version).in_([(s.name, s.version) for s in valid_packages]))
-    )
-
-    existing_rows = {(scan.name, scan.version) for scan in scalars.all()}
-
-    for scan in valid_packages:
-        if (scan.name, scan.version) not in existing_rows:
-            session.add(scan)
+        session.add(scan)
 
     session.commit()
 

--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -25,7 +25,7 @@ class PackageSpecifier(BaseModel):
     """
 
     name: str
-    version: Optional[str]
+    version: str
 
     class Config:
         frozen = True


### PR DESCRIPTION
Fix PR https://github.com/vipyrsec/dragonfly-mainframe/pull/151 to not ignore new packages. The order of the set difference was flipped. In addition to that, the tests were also faulty and did not catch the error. This has also been remediated.