### PR TITLE
Drop Sentry to profile 5% of interactions

### DIFF
--- a/src/mainframe/server.py
+++ b/src/mainframe/server.py
@@ -88,8 +88,8 @@ sentry_sdk.init(
     dsn=Sentry.dsn,
     environment=Sentry.environment,
     send_default_pii=True,
-    traces_sample_rate=0.25,
-    profiles_sample_rate=0.25,
+    traces_sample_rate=0.05,
+    profiles_sample_rate=0.05,
     release=f"{Sentry.release_prefix}@{GIT_SHA}",
     integrations=[LoggingIntegration(event_level=None, level=None)],
 )


### PR DESCRIPTION
Closes #136

Sentry seems to be receiving data correctly, but we're blowing through our quotas ridiculously quickly.
After some quick napkin math, it looks like setting Sentry to profile 5% of interactions should keep us just a hair under our quotas.