### PR TITLE
Remove trailing slash in get commit hash endpoint

### DIFF
--- a/src/mainframe/rules.py
+++ b/src/mainframe/rules.py
@@ -23,7 +23,7 @@ def build_auth_header(access_token: str) -> dict[str, str]:
 
 def fetch_commit_hash(http_session: Session, *, repository: str, access_token: str) -> str:
     """Fetch the top commit hash of the given repository"""
-    url = f"https://api.github.com/repos/{repository}/commits/main/"
+    url = f"https://api.github.com/repos/{repository}/commits/main"
     authentication_headers = build_auth_header(access_token)
     json_headers = {"Accept": "application/vnd.github.VERSION.sha"}
     headers = authentication_headers | json_headers

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -24,7 +24,7 @@ def test_build_auth_header():
 
 def test_fetch_commit_hash():
     mock_session: Any = Mock()
-    url = "https://api.github.com/repos/owner-name/repo-name/commits/main/"
+    url = "https://api.github.com/repos/owner-name/repo-name/commits/main"
     headers = {
         "Authorization": "Bearer token",
         "Accept": "application/vnd.github.VERSION.sha",


### PR DESCRIPTION
GitHub does not like it when there's a trailing slash in the get commit hash API endpoint