### PR TITLE
Add index to `scans.finished_at`

### DIFF
--- a/alembic/versions/94f1cd79b7d4_add_scans_finished_at_index.py
+++ b/alembic/versions/94f1cd79b7d4_add_scans_finished_at_index.py
@@ -1,0 +1,22 @@
+"""add scans finished at index
+
+Revision ID: 94f1cd79b7d4
+Revises: 9ac5b6c4a36b
+Create Date: 2023-09-27 15:37:05.455517
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "94f1cd79b7d4"
+down_revision = "9ac5b6c4a36b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(op.f("ix_scans_finished_at"), "scans", ["finished_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_scans_finished_at"), table_name="scans")

--- a/src/mainframe/models/orm.py
+++ b/src/mainframe/models/orm.py
@@ -79,7 +79,7 @@ class Scan(Base):
     pending_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     pending_by: Mapped[Optional[str]]
 
-    finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), index=True)
     finished_by: Mapped[Optional[str]]
 
     reported_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))


### PR DESCRIPTION
Improves perf by like 7x.
# Benchmark script
```sh
#!/bin/bash
pgbench -n -f query.sql -T120 -P24 -c5 -j5 \
    postgresql://postgres:postgres@localhost:5432/dragonfly
```
# Existing
```
number of transactions actually processed: 15987
latency average = 37.524 ms
latency stddev = 11.284 ms
tps = 133.229818 (without initial connection time)
```
# After
```
number of transactions actually processed: 117929
latency average = 5.086 ms
latency stddev = 0.629 ms
tps = 982.929644 (without initial connection time)
```