### PR TITLE
Remove "VERSION" from GitHub Accept header

### DIFF
--- a/src/mainframe/rules.py
+++ b/src/mainframe/rules.py
@@ -25,7 +25,7 @@ def fetch_commit_hash(http_session: Session, *, repository: str, access_token: s
     """Fetch the top commit hash of the given repository"""
     url = f"https://api.github.com/repos/{repository}/commits/main"
     authentication_headers = build_auth_header(access_token)
-    json_headers = {"Accept": "application/vnd.github.VERSION.sha"}
+    json_headers = {"Accept": "application/vnd.github.sha"}
     headers = authentication_headers | json_headers
     with http_session.get(url, headers=headers) as res:
         return res.text

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -27,7 +27,7 @@ def test_fetch_commit_hash():
     url = "https://api.github.com/repos/owner-name/repo-name/commits/main"
     headers = {
         "Authorization": "Bearer token",
-        "Accept": "application/vnd.github.VERSION.sha",
+        "Accept": "application/vnd.github.sha",
     }
 
     attrs = {"return_value.__enter__.return_value.text": "test commit hash"}


### PR DESCRIPTION
Most of the blogposts online show using "application/vnd.github.VERSION.sha" to retrieve just the SHA, but according to GitHub's [docs](https://docs.github.com/en/rest/using-the-rest-api/media-types?apiVersion=2022-11-28#sha-media-type-for-commits-commit-comparison-and-pull-requests) it's supposed to be "application/vnd.github.sha".

I have tested both, and they appear to work the same. I don't know what the difference is, but I'd like to use the one that's officially documented and supported.