### PR TITLE
Consistently pin all CI dependencies to commit hashes

### DIFF
--- a/.github/workflows/container-build-push.yaml
+++ b/.github/workflows/container-build-push.yaml
@@ -1,4 +1,4 @@
-name: "Docker Build and Push"
+name: "Container Build and Push"
 
 on:
   push:
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   build-push:
-    uses: darbiadev/.github/.github/workflows/docker-build-push.yaml@main
+    uses: darbiadev/.github/.github/workflows/docker-build-push.yaml@ea97d99e1520c46080c4c9032a69552e491474ac # v13.0.0

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -11,11 +11,11 @@ jobs:
   lint_test:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout repo"
-        uses: actions/checkout@v4
+      - name: "Checkout repository"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: "Setup PDM"
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@c050bdcb2405837648035b6678c75609d53a749f # v4
         with:
           python-version: "3.11"
           cache: true

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: "Setup PDM"
-        uses: pdm-project/setup-pdm@ddc33ca746b5716353581f988b29464200212702 # v3.3
+        uses: pdm-project/setup-pdm@c050bdcb2405837648035b6678c75609d53a749f # v4
         with:
           python-version: "3.11"
           cache: true

--- a/.github/workflows/sentry-release.yaml
+++ b/.github/workflows/sentry-release.yaml
@@ -10,10 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: "Checkout repository"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Create Sentry release
-        uses: getsentry/action-release@v1
+      - name: "Create Sentry release"
+        uses: getsentry/action-release@4744f6a65149f441c5f396d5b0877307c0db52c7 # v1.4.1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}


### PR DESCRIPTION
Trying to fix Dependabot failing with an "unknown error" on `pdm-project/setup-pdm`