### PR TITLE
Move duplicate CODEOWNERS entries to single line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @vipyrsec/core-developers
-* @vipyrsec/security-reviewers
+* @vipyrsec/core-developers @vipyrsec/security-reviewers


### PR DESCRIPTION
Duplicate entries _replace_ the context instead of _appending_ to it.