### PR TITLE
Eagerly load scan attributes

### DIFF
--- a/src/mainframe/endpoints/job.py
+++ b/src/mainframe/endpoints/job.py
@@ -4,7 +4,7 @@ from typing import Annotated
 import structlog
 from fastapi import APIRouter, Depends
 from sqlalchemy import and_, or_, select
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session, joinedload
 
 from mainframe.constants import mainframe_settings
 from mainframe.database import get_db
@@ -53,9 +53,8 @@ def get_jobs(
         )
         .order_by(Scan.pending_at.nulls_first(), Scan.queued_at)
         .limit(batch)
-        .options(selectinload(Scan.download_urls))
-        .with_for_update()
-    ).all()
+        .options(joinedload(Scan.download_urls))
+    ).unique().all()
 
     response_body: list[JobResult] = []
     for scan in scans:

--- a/src/mainframe/endpoints/report.py
+++ b/src/mainframe/endpoints/report.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
 from letsbuilda.pypi import PackageNotFoundError, PyPIServices
 from sqlalchemy import select
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session, joinedload
 
 from mainframe.constants import mainframe_settings
 from mainframe.database import get_db
@@ -44,8 +44,8 @@ def _lookup_package(name: str, version: str, session: Session) -> Scan:
 
     log = logger.bind(package={"name": name, "version": version})
 
-    query = select(Scan).where(Scan.name == name).options(selectinload(Scan.rules))
-    scans = session.scalars(query).all()
+    query = select(Scan).where(Scan.name == name).options(joinedload(Scan.rules))
+    scans = session.scalars(query).unique().all()
 
     if not scans:
         error = HTTPException(404, detail=f"No records for package `{name}` were found in the database")


### PR DESCRIPTION
We don't need laziness here; we're using the entire list of rules or download_urls, so `joinedload` is more suitable to avoid N+1 problems.