### PR TITLE
Use only one SQL query in `POST /jobs`

### DIFF
--- a/src/mainframe/endpoints/job.py
+++ b/src/mainframe/endpoints/job.py
@@ -3,8 +3,8 @@ from typing import Annotated
 
 import structlog
 from fastapi import APIRouter, Depends
-from sqlalchemy import and_, or_, select
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy import and_, or_, select, update
+from sqlalchemy.orm import Session, joinedload, aliased
 
 from mainframe.constants import mainframe_settings
 from mainframe.database import get_db
@@ -40,33 +40,35 @@ def get_jobs(
     packages are always processed after newly queued packages.
     """
 
-    scans = (
-        session.scalars(
-            select(Scan)
-            .where(
-                or_(
-                    Scan.status == Status.QUEUED,
-                    and_(
-                        Scan.pending_at
-                        < datetime.now(timezone.utc) - timedelta(seconds=mainframe_settings.job_timeout),
-                        Scan.status == Status.PENDING,
-                    ),
-                )
+    # Use a CTE to limit the number of rows we fetch
+    cte = (
+        select(Scan)
+        .where(
+            or_(
+                Scan.status == Status.QUEUED,
+                and_(
+                    Scan.pending_at < datetime.now(timezone.utc) - timedelta(seconds=mainframe_settings.job_timeout),
+                    Scan.status == Status.PENDING,
+                ),
             )
-            .order_by(Scan.pending_at.nulls_first(), Scan.queued_at)
-            .limit(batch)
-            .options(joinedload(Scan.download_urls))
         )
-        .unique()
-        .all()
+        .limit(batch)
+        .options(joinedload(Scan.download_urls))
+        .cte()
+    )
+
+    scan_cte = aliased(Scan, cte)
+
+    # Uses a Postgres `UPDATE .. FROM`. https://docs.sqlalchemy.org/en/20/tutorial/data_update.html#update-from
+    scans = session.scalars(
+        update(Scan)
+        .where(Scan.scan_id == scan_cte.scan_id)
+        .values(status=Status.PENDING, pending_at=datetime.now(timezone.utc), pending_by=auth.subject)
+        .returning(Scan)
     )
 
     response_body: list[JobResult] = []
     for scan in scans:
-        scan.status = Status.PENDING
-        scan.pending_at = datetime.now(timezone.utc)
-        scan.pending_by = auth.subject
-
         logger.info(
             "Job given and status set to pending in database",
             package={
@@ -87,7 +89,5 @@ def get_jobs(
         )
 
         response_body.append(job_result)
-
-    session.commit()
 
     return response_body


### PR DESCRIPTION
Instead of selecting and updating with 2 queries, simply update and get the updated rows using `RETURNING`.

This has the added benefit of making this operation atomic, when it was not before.