### PR TITLE
Reduce SQLA connection pool size to 5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,8 @@ You'll need to have the following environment variables set.
 | | | | |
 | `REPORTER_URL` | str | "" | The url of the reporter microservice |
 | `DB_URL` | str | "postgresql+psycopg2://postgres:postgres@localhost:5432" | PostgreSQL database connection string |
+| `DB_CONNECTION_POOL_MAX_SIZE` | int | 15 | The max number of concurrent database connections |
+| `DB_CONNECTION_POOL_PERSISTENT_SIZE` | int | 5 | The number of concurrent database connections to maintain in the connection pool |
 | | | | |
 | `SENTRY_DSN` | str | "" | Sentry Data Source Name (DSN) |
 | `SENTRY_ENVIRONMENT` | str | "" | Sentry environment |

--- a/compose-tests.yaml
+++ b/compose-tests.yaml
@@ -6,4 +6,4 @@ services:
         GIT_SHA: testing
 
   db:
-    command: -c fsync=off -c full_page_writes=off
+    command: "-c fsync=off -c full_page_writes=off -c max_connections=25"

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     tty: true
     restart: always
     environment:
-      DB_URL: postgresql+psycopg2://postgres:postgres@db:5432
+      DB_URL: "postgresql+psycopg2://postgres:postgres@db:5432/dragonfly"
       MICROSOFT_TENANT_ID: tenant_id
       MICROSOFT_CLIENT_ID: client_id
       MICROSOFT_CLIENT_SECRET: client_secret
@@ -30,3 +30,4 @@ services:
       - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: dragonfly

--- a/src/mainframe/constants.py
+++ b/src/mainframe/constants.py
@@ -24,7 +24,7 @@ class Mainframe(EnvConfig):
 
     reporter_url: str = ""
 
-    db_url: str = "postgresql+psycopg2://postgres:postgres@localhost:5432"
+    db_url: str = "postgresql+psycopg2://postgres:postgres@localhost:5432/dragonfly"
 
     dragonfly_github_token: str
 

--- a/src/mainframe/constants.py
+++ b/src/mainframe/constants.py
@@ -25,6 +25,10 @@ class Mainframe(EnvConfig):
     reporter_url: str = ""
 
     db_url: str = "postgresql+psycopg2://postgres:postgres@localhost:5432/dragonfly"
+    db_connection_pool_max_size: int = 15
+    """The max number of concurrent connections"""
+    db_connection_pool_persistent_size: int = 5
+    """The number of concurrent connections to maintain in the connection pool"""
 
     dragonfly_github_token: str
 

--- a/src/mainframe/database.py
+++ b/src/mainframe/database.py
@@ -5,7 +5,9 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from mainframe.constants import mainframe_settings
 
-engine = create_engine(mainframe_settings.db_url, pool_size=25)
+# pool_size and max_overflow are set to their default values. There is never
+# enough load to justify increasing them.
+engine = create_engine(mainframe_settings.db_url, pool_size=5, max_overflow=10)
 sessionmaker = sessionmaker(bind=engine, expire_on_commit=False)
 
 

--- a/src/mainframe/database.py
+++ b/src/mainframe/database.py
@@ -7,7 +7,11 @@ from mainframe.constants import mainframe_settings
 
 # pool_size and max_overflow are set to their default values. There is never
 # enough load to justify increasing them.
-engine = create_engine(mainframe_settings.db_url, pool_size=5, max_overflow=10)
+engine = create_engine(
+    mainframe_settings.db_url,
+    pool_size=mainframe_settings.db_connection_pool_persistent_size,
+    max_overflow=mainframe_settings.db_connection_pool_max_size - mainframe_settings.db_connection_pool_persistent_size,
+)
 sessionmaker = sessionmaker(bind=engine, expire_on_commit=False)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,10 +9,9 @@ import pytest
 from letsbuilda.pypi import PyPIServices
 from letsbuilda.pypi.models import Package
 from letsbuilda.pypi.models.models_package import Distribution, Release
-from sqlalchemy import Engine, create_engine
+from sqlalchemy import Engine, create_engine, text
 from sqlalchemy.orm import Session, sessionmaker
 
-from mainframe.constants import mainframe_settings
 from mainframe.json_web_token import AuthenticationData
 from mainframe.models.orm import Base, Scan
 from mainframe.rules import Rules
@@ -29,8 +28,26 @@ def sm(engine: Engine) -> sessionmaker[Session]:
 
 
 @pytest.fixture(scope="session")
-def engine() -> Engine:
-    return create_engine(mainframe_settings.db_url, pool_size=5, max_overflow=17)
+def superuser_engine() -> Engine:
+    """
+    Creates an engine using a user with superuser permissions.
+
+    This should only be used for tests that need superuser permissions.
+    Otherwise, tests should prefer the `engine` fixture in order to better
+    mimic the production user.
+    """
+    return create_engine("postgresql+psycopg2://postgres:postgres@db:5432/dragonfly", pool_size=5, max_overflow=17)
+
+
+@pytest.fixture(scope="session")
+def engine(superuser_engine: Engine) -> Engine:
+    with Session(bind=superuser_engine) as s, s.begin():
+        s.execute(text("DROP USER IF EXISTS dragonfly"))
+        s.execute(text("CREATE USER dragonfly WITH LOGIN PASSWORD 'postgres'"))
+        s.execute(text("GRANT pg_read_all_data TO dragonfly"))
+        s.execute(text("GRANT pg_write_all_data TO dragonfly"))
+
+    return create_engine("postgresql+psycopg2://dragonfly:postgres@db:5432/dragonfly", pool_size=5, max_overflow=17)
 
 
 @pytest.fixture(params=data, scope="session")
@@ -39,16 +56,18 @@ def test_data(request: pytest.FixtureRequest) -> list[Scan]:
 
 
 @pytest.fixture(autouse=True)
-def db_session(engine: Engine, test_data: list[Scan], sm: sessionmaker[Session]) -> Generator[Session, None, None]:
-    Base.metadata.drop_all(engine)
-    Base.metadata.create_all(engine)
+def db_session(
+    superuser_engine: Engine, test_data: list[Scan], sm: sessionmaker[Session]
+) -> Generator[Session, None, None]:
+    Base.metadata.drop_all(superuser_engine)
+    Base.metadata.create_all(superuser_engine)
     with sm() as s, s.begin():
         s.add_all(deepcopy(test_data))
 
     with sm() as s:
         yield s
 
-    Base.metadata.drop_all(engine)
+    Base.metadata.drop_all(superuser_engine)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def superuser_engine() -> Engine:
     Otherwise, tests should prefer the `engine` fixture in order to better
     mimic the production user.
     """
-    return create_engine("postgresql+psycopg2://postgres:postgres@db:5432/dragonfly", pool_size=5, max_overflow=17)
+    return create_engine("postgresql+psycopg2://postgres:postgres@db:5432/dragonfly", pool_size=5, max_overflow=10)
 
 
 @pytest.fixture(scope="session")
@@ -47,7 +47,7 @@ def engine(superuser_engine: Engine) -> Engine:
         s.execute(text("GRANT pg_read_all_data TO dragonfly"))
         s.execute(text("GRANT pg_write_all_data TO dragonfly"))
 
-    return create_engine("postgresql+psycopg2://dragonfly:postgres@db:5432/dragonfly", pool_size=5, max_overflow=17)
+    return create_engine("postgresql+psycopg2://dragonfly:postgres@db:5432/dragonfly", pool_size=5, max_overflow=10)
 
 
 @pytest.fixture(params=data, scope="session")

--- a/tests/test_dbconfig.py
+++ b/tests/test_dbconfig.py
@@ -1,0 +1,51 @@
+from threading import Barrier
+from concurrent.futures import ThreadPoolExecutor
+from mainframe.models.orm import Scan, Status
+from mainframe.endpoints.job import get_jobs
+import itertools
+import string
+from unittest.mock import Mock
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def test_database_reaches_max_connections(db_session: Session, sm: sessionmaker[Session]):
+    """
+    A regression test for improper connection pool config.
+    """
+
+    # chosen to make sure we exceed the connection pool threshold of 25
+    n_senders = 30
+
+    # insert a lot of queued packages so our threads have something to return
+    with db_session.begin():
+        db_session.add_all(
+            [
+                Scan(
+                    name="".join(x),
+                    version="1.0.0",
+                    status=Status.QUEUED,
+                    queued_by="remmy",
+                    download_urls=[],
+                )
+                for x in itertools.islice(itertools.product(string.ascii_lowercase, repeat=2), n_senders)
+            ]
+        )
+
+    b = Barrier(n_senders)
+
+    auth = Mock()
+    auth.subject = "remmy"
+    state = Mock()
+    state.rules_commit = "0xc0ffee"
+
+    # spawn many threads, wait for them all to be ready, then send many
+    # concurrent job requests
+    def sender(_: int):
+        b.wait()
+        with sm() as session:
+            r = get_jobs(session, auth, state)  # type: ignore
+        return r
+
+    with ThreadPoolExecutor(max_workers=n_senders) as tpe:
+        for r in tpe.map(sender, range(n_senders), timeout=30):
+            assert r != []


### PR DESCRIPTION
Currently, the database is configured to have 25 max connections, with 3 reserved for superuser connections.

Closes #231.