### PR TITLE
Only map localhost to test containers

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: Containerfile
 
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     depends_on:
       db:
         condition: service_healthy
@@ -32,6 +32,6 @@ services:
       timeout: 5s
       retries: 10
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Only attaching to localhost makes tests less susceptible to malware looking to attack the exposed database or mainframe services