### PR TITLE
Close DB sessions in functions that use FastAPI dependency injection

### DIFF
--- a/src/mainframe/database.py
+++ b/src/mainframe/database.py
@@ -12,7 +12,7 @@ engine = create_engine(
     pool_size=mainframe_settings.db_connection_pool_persistent_size,
     max_overflow=mainframe_settings.db_connection_pool_max_size - mainframe_settings.db_connection_pool_persistent_size,
 )
-sessionmaker = sessionmaker(bind=engine, expire_on_commit=False)
+sessionmaker = sessionmaker(bind=engine, expire_on_commit=False, autobegin=False)
 
 
 def get_db() -> Generator[Session, None, None]:

--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -42,9 +42,10 @@ def submit_results(
     name = result.name
     version = result.version
 
-    scan = session.scalar(
-        select(Scan).where(Scan.name == name).where(Scan.version == version).options(joinedload(Scan.rules))
-    )
+    with session.begin():
+        scan = session.scalar(
+            select(Scan).where(Scan.name == name).where(Scan.version == version).options(joinedload(Scan.rules))
+        )
 
     log = logger.bind(package={"name": name, "version": version})
 
@@ -62,28 +63,29 @@ def submit_results(
         )
         raise error
 
-    if isinstance(result, PackageScanResultFail):
-        scan.status = Status.FAILED
-        scan.fail_reason = result.reason
+    with session, session.begin():
+        if isinstance(result, PackageScanResultFail):
+            scan.status = Status.FAILED
+            scan.fail_reason = result.reason
 
-        session.commit()
-        return
+            session.commit()
+            return
 
-    scan.status = Status.FINISHED
-    scan.finished_at = dt.datetime.now(dt.timezone.utc)
-    scan.inspector_url = result.inspector_url
-    scan.score = result.score
-    scan.finished_by = auth.subject
-    scan.commit_hash = result.commit
+        scan.status = Status.FINISHED
+        scan.finished_at = dt.datetime.now(dt.timezone.utc)
+        scan.inspector_url = result.inspector_url
+        scan.score = result.score
+        scan.finished_by = auth.subject
+        scan.commit_hash = result.commit
 
-    # These are the rules that already have an entry in the database
-    rules = session.scalars(select(Rule).where(Rule.name.in_(result.rules_matched))).all()
-    rule_names = {rule.name for rule in rules}
-    scan.rules.extend(rules)
+        # These are the rules that already have an entry in the database
+        rules = session.scalars(select(Rule).where(Rule.name.in_(result.rules_matched))).all()
+        rule_names = {rule.name for rule in rules}
+        scan.rules.extend(rules)
 
-    # These are the rules that had to be created
-    new_rules = [Rule(name=rule_name) for rule_name in result.rules_matched if rule_name not in rule_names]
-    scan.rules.extend(new_rules)
+        # These are the rules that had to be created
+        new_rules = [Rule(name=rule_name) for rule_name in result.rules_matched if rule_name not in rule_names]
+        scan.rules.extend(new_rules)
 
     log.info(
         "Scan results submitted",
@@ -100,8 +102,6 @@ def submit_results(
         },
         tag="scan_submitted",
     )
-
-    session.commit()
 
 
 @router.get(
@@ -166,10 +166,10 @@ def lookup_package_info(
     if nn_since:
         query = query.where(Scan.finished_at >= dt.datetime.fromtimestamp(since, tz=dt.timezone.utc))
 
-    data = session.scalars(query)
+    with session, session.begin():
+        data = session.scalars(query).unique().all()
 
-    log.info("Package information queried")
-    return data.unique().all()
+    return data
 
 
 def _deduplicate_packages(packages: list[PackageSpecifier], session: Session) -> set[tuple[str, str]]:
@@ -208,22 +208,21 @@ def batch_queue_package(
     auth: Annotated[AuthenticationData, Depends(validate_token)],
     pypi_client: Annotated[PyPIServices, Depends(get_pypi_client)],
 ):
-    packages_to_check = _deduplicate_packages(packages, session)
+    with session, session.begin():
+        packages_to_check = _deduplicate_packages(packages, session)
 
-    for package_metadata in _get_packages_metadata(pypi_client, packages_to_check):
-        scan = Scan(
-            name=package_metadata.title,
-            version=package_metadata.releases[0].version,
-            status=Status.QUEUED,
-            queued_by=auth.subject,
-            download_urls=[
-                DownloadURL(url=distribution.url) for distribution in package_metadata.releases[0].distributions
-            ],
-        )
+        for package_metadata in _get_packages_metadata(pypi_client, packages_to_check):
+            scan = Scan(
+                name=package_metadata.title,
+                version=package_metadata.releases[0].version,
+                status=Status.QUEUED,
+                queued_by=auth.subject,
+                download_urls=[
+                    DownloadURL(url=distribution.url) for distribution in package_metadata.releases[0].distributions
+                ],
+            )
 
-        session.add(scan)
-
-    session.commit()
+            session.add(scan)
 
 
 @router.post(
@@ -277,10 +276,9 @@ def queue_package(
         ],
     )
 
-    session.add(new_package)
-
     try:
-        session.commit()
+        with session, session.begin():
+            session.add(new_package)
     except IntegrityError:
         log.warn(f"Package {name}@{version} already queued for scanning.", tag="already_queued")
         raise HTTPException(409, f"Package {name}@{version} is already queued for scanning")

--- a/src/mainframe/endpoints/report.py
+++ b/src/mainframe/endpoints/report.py
@@ -45,7 +45,8 @@ def _lookup_package(name: str, version: str, session: Session) -> Scan:
     log = logger.bind(package={"name": name, "version": version})
 
     query = select(Scan).where(Scan.name == name).options(joinedload(Scan.rules))
-    scans = session.scalars(query).unique().all()
+    with session.begin():
+        scans = session.scalars(query).unique().all()
 
     if not scans:
         error = HTTPException(404, detail=f"No records for package `{name}` were found in the database")
@@ -70,7 +71,8 @@ def _lookup_package(name: str, version: str, session: Session) -> Scan:
             )
             raise error
 
-    scan = session.scalar(query.where(Scan.version == version))
+    with session.begin():
+        scan = session.scalar(query.where(Scan.version == version))
     if scan is None:
         error = HTTPException(
             404, detail=f"Package `{name}` has records in the database, but none with version `{version}`"
@@ -233,6 +235,12 @@ def report_package(
 
         httpx.post(f"{mainframe_settings.reporter_url}/report/{name}", json=jsonable_encoder(report))
 
+    with session.begin():
+        scan.reported_by = auth.subject
+        scan.reported_at = dt.datetime.now(dt.timezone.utc)
+
+    session.close()
+
     log.info(
         "Sent report",
         report_data={
@@ -245,7 +253,3 @@ def report_package(
         },
         reported_by=auth.subject,
     )
-
-    scan.reported_by = auth.subject
-    scan.reported_at = dt.datetime.now(dt.timezone.utc)
-    session.commit()

--- a/src/mainframe/endpoints/stats.py
+++ b/src/mainframe/endpoints/stats.py
@@ -44,8 +44,9 @@ def _get_failed_packages(session: Session) -> int:
 
 @router.get("/stats", dependencies=[Depends(validate_token)])
 def get_stats(session: Annotated[Session, Depends(get_db)]) -> StatsResponse:
-    return StatsResponse(
-        ingested=_get_package_ingest(session),
-        average_scan_time=_get_average_scan_time(session),
-        failed=_get_failed_packages(session),
-    )
+    with session, session.begin():
+        return StatsResponse(
+            ingested=_get_package_ingest(session),
+            average_scan_time=_get_average_scan_time(session),
+            failed=_get_failed_packages(session),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__file__)
 
 @pytest.fixture(scope="session")
 def sm(engine: Engine) -> sessionmaker[Session]:
-    return sessionmaker(bind=engine, expire_on_commit=False)
+    return sessionmaker(bind=engine, expire_on_commit=False, autobegin=False)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -11,7 +11,7 @@ from letsbuilda.pypi import PyPIServices
 from letsbuilda.pypi.exceptions import PackageNotFoundError
 from pytest import MonkeyPatch
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from mainframe.endpoints.report import (
     _lookup_package,  # pyright: ignore [reportPrivateUsage]
@@ -76,6 +76,7 @@ from mainframe.models.schemas import (
     ],
 )
 def test_report(
+    sm: sessionmaker[Session],
     db_session: Session,
     auth: AuthenticationData,
     pypi_client: PyPIServices,
@@ -103,20 +104,21 @@ def test_report(
         commit_hash="test commit hash",
     )
 
-    db_session.add(scan)
-    db_session.commit()
+    with db_session.begin():
+        db_session.add(scan)
 
     httpx.post = MagicMock()
 
-    report_package(body, db_session, auth, pypi_client)
+    report_package(body, sm(), auth, pypi_client)
 
     httpx.post.assert_called_once_with(url, json=jsonable_encoder(expected))
 
-    scan = db_session.scalar(select(Scan).where(Scan.name == "c").where(Scan.version == "1.0.0"))
+    with sm() as sess, sess.begin():
+        s = sess.scalar(select(Scan).where(Scan.name == "c").where(Scan.version == "1.0.0"))
 
-    assert scan is not None
-    assert scan.reported_by == auth.subject
-    assert scan.reported_at is not None
+    assert s is not None
+    assert s.reported_by == auth.subject
+    assert s.reported_at is not None
 
 
 def test_report_package_not_on_pypi(
@@ -160,8 +162,8 @@ def test_report_invalid_version(db_session: Session):
         fail_reason=None,
         commit_hash="test commit hash",
     )
-    db_session.add(scan)
-    db_session.commit()
+    with db_session.begin():
+        db_session.add(scan)
 
     with pytest.raises(HTTPException) as e:
         _lookup_package("c", "2.0.0", db_session)
@@ -382,8 +384,8 @@ def test_report_lookup_package(db_session: Session):
         commit_hash="test commit hash",
     )
 
-    db_session.add(scan)
-    db_session.commit()
+    with db_session.begin():
+        db_session.add(scan)
 
     res = _lookup_package("c", "1.0.0", db_session)
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -27,9 +27,8 @@ def test_stats(db_session: Session):
         fail_reason=None,
         commit_hash="test commit hash",
     )
-
-    db_session.add(scan)
-    db_session.commit()
+    with db_session.begin():
+        db_session.add(scan)
 
     stats = get_stats(db_session)
     assert stats.ingested == 1


### PR DESCRIPTION
Also turn off autobegin to make db transactions more explicit.

Closes #235.