### PR TITLE
Fix enum serialization

### DIFF
--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -47,7 +47,7 @@ class Package(BaseModel):
             scan_id=str(scan.scan_id),
             name=scan.name,
             version=scan.version,
-            status=str(scan.status),
+            status=scan.status.name.lower(),
             score=scan.score,  # pyright: ignore
             inspector_url=scan.inspector_url,
             rules=[rule.name for rule in scan.rules],

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -271,6 +271,7 @@ def test_package_from_db():
     scan = Scan(
         name="pyfoo",
         version="3.12.2",
+        status=Status.FINISHED,
         score=14,
         queued_by="Ryan",
         reported_by="Ryan",
@@ -293,6 +294,7 @@ def test_datetime_serialization():
     scan = Scan(
         name="Pyfoo",
         version="3.13.0",
+        status=Status.FINISHED,
         queued_at=datetime(2023, 10, 12, 13, 45, 30),
         pending_at=datetime(2023, 10, 12, 13, 45, 30),
         finished_at=datetime(2023, 10, 12, 13, 45, 30),


### PR DESCRIPTION
The Status enum was being serialized in a format similar to Status.FINISHED, which was bad for consumers as they were expected something like "finished". This hotfix should revert it back to how it was before.