### PR TITLE
Remove redundant version override

### DIFF
--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -275,9 +275,6 @@ def queue_package(
         )
         raise error
 
-    version = package_metadata.releases[0].version  # Use latest version if not provided
-    log = logger.bind(package={"name": name, "version": version})
-
     new_package = Scan(
         name=name,
         version=version,


### PR DESCRIPTION
The version is always specified, so this line doesn't do anything.

Closes #264 