### PR TITLE
Revert "Add build-system to pyproject.toml and fix version specifier"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN pip install pdm
 
 WORKDIR /app
 COPY pyproject.toml pdm.lock ./
-COPY src/ src/
 RUN mkdir __pypackages__ && pdm install --prod --no-lock --no-editable
+COPY src/ src/
 RUN pdm install --prod --no-lock --no-editable
 
 FROM builder as test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,8 @@ dynamic = ["version"]
 repository = "https://github.com/vipyrsec/dragonfly-mainframe/"
 documentation = "https://docs.vipyrsec.dev/dragonfly-mainframe/"
 
-[build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
-
 [tool.pdm]
-version = { source = "file", path = "src/mainframe/__init__.py" }
+version = { source = "file", path = "mypackage/__init__.py" }
 
 [tool.pdm.dev-dependencies]
 lint = [


### PR DESCRIPTION
Reverts vipyrsec/dragonfly-mainframe#145

#270 