### PR TITLE
Create response model for `GET /package`

### DIFF
--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -1,7 +1,10 @@
+import datetime
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
+
+from .orm import Scan
 
 
 class ServerMetadata(BaseModel):
@@ -15,6 +18,63 @@ class Error(BaseModel):
     """Error"""
 
     detail: str
+
+
+class Package(BaseModel):
+    """Model representing a package queried from the database."""
+
+    scan_id: str
+    name: str
+    version: Optional[str]
+    status: Optional[str]
+    score: Optional[int]
+    inspector_url: Optional[str]
+    rules: list[str] = []
+    download_urls: list[str] = []
+    queued_at: Optional[datetime.datetime]
+    queued_by: Optional[str]
+    reported_at: Optional[datetime.datetime]
+    reported_by: Optional[str]
+
+    pending_at: Optional[datetime.datetime]
+
+    pending_by: Optional[str]
+    finished_at: Optional[datetime.datetime]
+    finished_by: Optional[str]
+
+    commit_hash: Optional[str]
+
+    @classmethod
+    def from_db(cls, scan: Scan):
+        return cls(
+            scan_id=str(scan.scan_id),
+            name=scan.name,
+            version=scan.version,
+            status=scan.status.name.lower(),
+            score=scan.score,
+            inspector_url=scan.inspector_url,
+            rules=[rule.name for rule in scan.rules],
+            download_urls=[url.url for url in scan.download_urls],
+            reported_at=scan.reported_at,
+            reported_by=scan.reported_by,
+            queued_at=scan.queued_at,
+            queued_by=scan.queued_by,
+            pending_at=scan.pending_at,
+            pending_by=scan.pending_by,
+            finished_at=scan.finished_at,
+            finished_by=scan.finished_by,
+            commit_hash=scan.commit_hash,
+        )
+
+    @field_serializer(
+        "queued_at",
+        "pending_at",
+        "finished_at",
+        "reported_at",
+    )
+    def serialize_dt(self, dt: Optional[datetime.datetime], _info):  # pyright: ignore
+        if dt:
+            return int(dt.timestamp())
 
 
 class PackageSpecifier(BaseModel):


### PR DESCRIPTION
Combines the changes of:
* https://github.com/vipyrsec/dragonfly-mainframe/pull/259
* https://github.com/vipyrsec/dragonfly-mainframe/pull/202

Re-reverting:
* https://github.com/vipyrsec/dragonfly-mainframe/pull/271
* https://github.com/vipyrsec/dragonfly-mainframe/pull/273

Both at once because #259 is a fix for #202. Deploying this should be accompanied by pinning bot to `92e2b3332521860326c6dc6ca71f548fa0ce9fe2`