### PR TITLE
Add Distribution model

### DIFF
--- a/alembic/versions/a62a93704798_add_distributions.py
+++ b/alembic/versions/a62a93704798_add_distributions.py
@@ -1,0 +1,23 @@
+"""add distributions
+
+Revision ID: a62a93704798
+Revises: 587c186d91ee
+Create Date: 2024-08-11 08:12:42.354151
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a62a93704798"
+down_revision = "587c186d91ee"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("scans", "files", new_column_name="distributions")
+
+
+def downgrade() -> None:
+    op.alter_column("scans", "distributions", new_column_name="files")

--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -78,7 +78,7 @@ def submit_results(
         scan.score = result.score
         scan.finished_by = auth.subject
         scan.commit_hash = result.commit
-        scan.files = result.files
+        scan.distributions = result.distributions
 
         # These are the rules that already have an entry in the database
         rules = session.scalars(select(Rule).where(Rule.name.in_(result.rules_matched))).all()

--- a/src/mainframe/models/orm.py
+++ b/src/mainframe/models/orm.py
@@ -28,7 +28,7 @@ from sqlalchemy.orm import (
 )
 
 from mainframe.models import Pydantic
-from mainframe.models.schemas import Files
+from mainframe.models.schemas import Distributions
 
 
 class Base(MappedAsDataclass, DeclarativeBase, kw_only=True):
@@ -102,7 +102,7 @@ class Scan(Base):
 
     commit_hash: Mapped[Optional[str]] = mapped_column(default=None)
 
-    files: Mapped[Optional[Files]] = mapped_column(Pydantic(Files), default=None)
+    distributions: Mapped[Optional[Distributions]] = mapped_column(Pydantic(Distributions), default=None)
 
 
 Index(None, Scan.status, postgresql_where=or_(Scan.status == Status.QUEUED, Scan.status == Status.PENDING))

--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -48,7 +48,15 @@ class File(BaseModel):
     matches: list[RuleMatch]
 
 
-Files = RootModel[list[File]]
+Files = list[File]
+
+
+class Distribution(BaseModel):
+    download_url: str
+    files: Files
+
+
+Distributions = RootModel[list[Distribution]]
 
 
 class ServerMetadata(BaseModel):
@@ -88,7 +96,7 @@ class Package(BaseModel):
 
     commit_hash: Optional[str]
 
-    files: Optional[Files]
+    distributions: Optional[Distributions]
 
     @classmethod
     def from_db(cls, scan: Scan):
@@ -110,7 +118,7 @@ class Package(BaseModel):
             finished_at=scan.finished_at,
             finished_by=scan.finished_by,
             commit_hash=scan.commit_hash,
-            files=scan.files,
+            distributions=scan.distributions,
         )
 
     @field_serializer(
@@ -179,7 +187,7 @@ class PackageScanResult(PackageSpecifier):
     score: int = 0
     inspector_url: Optional[str] = None
     rules_matched: list[str] = []
-    files: Optional[Files] = None
+    distributions: Optional[Distributions] = None
 
 
 class PackageScanResultFail(PackageSpecifier):


### PR DESCRIPTION
up migration
```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Generating static SQL
INFO  [alembic.runtime.migration] Will assume transactional DDL.
BEGIN;
INFO  [alembic.runtime.migration] Running upgrade 587c186d91ee -> a62a93704798, add distributions
-- Running upgrade 587c186d91ee -> a62a93704798
ALTER TABLE scans RENAME files TO distributions;
UPDATE alembic_version SET version_num='a62a93704798' WHERE alembic_version.version_num = '587c186d91ee';
COMMIT;
```

down migration
```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Generating static SQL
INFO  [alembic.runtime.migration] Will assume transactional DDL.
BEGIN;
INFO  [alembic.runtime.migration] Running downgrade a62a93704798 -> 587c186d91ee, add distributions
-- Running downgrade a62a93704798 -> 587c186d91ee
ALTER TABLE scans RENAME distributions TO files;
UPDATE alembic_version SET version_num='587c186d91ee' WHERE alembic_version.version_num = 'a62a93704798';
COMMIT;
```