### PR TITLE
Fix SQLAlchemy echoing logs duplicating

### DIFF
--- a/logging/development.toml
+++ b/logging/development.toml
@@ -11,9 +11,9 @@ propagate = true
 [loggers."sqlalchemy.engine"]
 handlers = ["default"]
 level = "INFO"
-propagate = true
+propagate = false
 
 [loggers."sqlalchemy.pool"]
 handlers = ["default"]
 level = "DEBUG"
-propagate = true
+propagate = false


### PR DESCRIPTION
SQLAlchemy echoing was logging twice. I switched the logging config to do `propagate=false` so that this would no longer happen.