### PR TITLE
fix: make the project version static

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dragonfly-mainframe"
+version = "0.2.0"
 description = "Distributes tasks to dragonfly-clients and handles package status updates."
 authors = [{name = "Vipyr Security Developers", email = "support@vipyrsec.com"}]
 license = {text = "MIT"}
 classifiers = ["Private :: Do Not Upload"]
-dynamic = ["version"]
 
 requires-python = ">=3.12,<3.13"
 dependencies = [
@@ -51,9 +51,6 @@ packages = ["src/mainframe"]
 
 [tool.hatch.metadata]
 allow-direct-references = true
-
-[tool.hatch.version]
-path = "src/mainframe/__init__.py"
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
@@ -260,6 +260,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfly-mainframe"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Dependabot apparently only fetches files like `pyproject.toml`, `requirements.txt`, `uv.lock`, etc. before bumping the packages, and so does not work with dynamic versioning.

REF: <https://github.com/vipyrsec/dragonfly-mainframe/actions/runs/17334827721/job/49218837037>
REF: <https://redirect.github.com/dependabot/dependabot-core/issues/12042>
REF: <https://github.com/dependabot/dependabot-core/blob/b300d4ddf3e7efe6ba2edafedbb9188d9235c2ba/uv/lib/dependabot/uv/file_fetcher.rb#L77-L91>
