### PR TITLE
Add support for Cloudflare Zero Trust

### DIFF
--- a/src/mainframe/authorization_header_elements.py
+++ b/src/mainframe/authorization_header_elements.py
@@ -26,11 +26,15 @@ def get_authorization_header_elements(
         return AuthorizationHeaderElements(authorization_scheme, bearer_token, valid)
 
 
-def get_bearer_token(request: StarletteRequest) -> str:
+def get_bearer_token(request: StarletteRequest) -> tuple[str, str]:
+    cf_authorization_header = request.headers.get("CF_Authorization")
+    if cf_authorization_header:
+        return ("cf", cf_authorization_header)
+
     authorization_header = request.headers.get("Authorization")
     if authorization_header:
         authorization_header_elements = get_authorization_header_elements(authorization_header)
         if authorization_header_elements.are_valid:
-            return authorization_header_elements.bearer_token
+            return ("auth0", authorization_header_elements.bearer_token)
         raise BadCredentialsException
     raise RequiresAuthenticationException

--- a/src/mainframe/constants.py
+++ b/src/mainframe/constants.py
@@ -47,3 +47,9 @@ class _Sentry(EnvConfig, env_prefix="sentry_"):
 
 
 Sentry = _Sentry()
+
+class CFAccess(EnvConfig, env_prefix="cf_access_"):
+    audience: str
+    team_domain: str = "https://vipyrsec.cloudflareaccess.com"
+
+cf_access_settings = CFAccess.model_validate({})

--- a/src/mainframe/constants.py
+++ b/src/mainframe/constants.py
@@ -48,8 +48,10 @@ class _Sentry(EnvConfig, env_prefix="sentry_"):
 
 Sentry = _Sentry()
 
+
 class CFAccess(EnvConfig, env_prefix="cf_access_"):
-    audience: str
+    audience: str = ""
     team_domain: str = "https://vipyrsec.cloudflareaccess.com"
+
 
 cf_access_settings = CFAccess.model_validate({})

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -34,7 +34,10 @@ def test_invalid_authorization_header_elements(inp: str):
 def test_get_bearer_token(monkeypatch: pytest.MonkeyPatch):
     request = cast("Request", Mock(spec=Request))
     monkeypatch.setattr(request, "headers", {"Authorization": "Bearer token"})
-    assert get_bearer_token(request) == "token"
+    assert get_bearer_token(request) == ("auth0", "token")
+
+    monkeypatch.setattr(request, "headers", {"CF_Authorization": "token"})
+    assert get_bearer_token(request) == ("cf", "token")
 
 
 def test_nonexistent_credentials(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
This PR is backwards compatible with our existing authentication system, however we can fully migrate over later on. This will require a separate PR.