### PR TITLE
Bump letsbuilda-pypi to 5.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "fastapi-pagination==0.15.8",
   "fastapi-slim==0.128.0",
   "httpx==0.28.1",
-  "letsbuilda-pypi @ git+https://github.com/vipyrsec/letsbuilda-pypi@c721bdf726324e808ef1dd9983d0fe7896c4c3fd",
+  "letsbuilda-pypi==5.2.2",
   "prometheus-client==0.24.1",
   "prometheus-fastapi-instrumentator==7.1.0",
   "psycopg2-binary==2.9.11",

--- a/uv.lock
+++ b/uv.lock
@@ -344,7 +344,7 @@ requires-dist = [
     { name = "fastapi-pagination", specifier = "==0.15.8" },
     { name = "fastapi-slim", specifier = "==0.128.0" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "letsbuilda-pypi", git = "https://github.com/vipyrsec/letsbuilda-pypi?rev=c721bdf726324e808ef1dd9983d0fe7896c4c3fd" },
+    { name = "letsbuilda-pypi", specifier = "==5.2.2" },
     { name = "prometheus-client", specifier = "==0.24.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = "==7.1.0" },
     { name = "psycopg2-binary", specifier = "==2.9.11" },
@@ -454,7 +454,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -566,11 +565,16 @@ wheels = [
 
 [[package]]
 name = "letsbuilda-pypi"
-version = "5.2.1"
-source = { git = "https://github.com/vipyrsec/letsbuilda-pypi?rev=c721bdf726324e808ef1dd9983d0fe7896c4c3fd#c721bdf726324e808ef1dd9983d0fe7896c4c3fd" }
+version = "5.2.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
+    { name = "pydantic" },
     { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/f5/b8d9b159cb80d03c01252330eee52d8702f2bb8068a4a889e4c6e1f68a5c/letsbuilda_pypi-5.2.2.tar.gz", hash = "sha256:2e339b887d21b84f9373650a0c165b27bb2d36153cae526671a6d23de79a62eb", size = 8293, upload-time = "2026-07-07T21:05:34.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/26/0200ac9e35c35e23793b2d0a5c22aa15aa801dbdf1a359c31693415c357e/letsbuilda_pypi-5.2.2-py3-none-any.whl", hash = "sha256:548f2228bc8c5f39d12f0340741fdc94819839f4f1711d0983f79dfd5c6bf724", size = 8157, upload-time = "2026-07-07T21:05:33.016Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This version handles fields not defined in the model better