### PR TITLE
Remove letsbuilda-pypi as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   "fastapi-pagination==0.15.8",
   "fastapi>=0.128.0",
   "httpx==0.28.1",
-  "letsbuilda-pypi==6.0.1",
   "prometheus-client==0.24.1",
   "prometheus-fastapi-instrumentator==8.0.1",
   "psycopg2-binary==2.9.11",

--- a/src/mainframe/dependencies.py
+++ b/src/mainframe/dependencies.py
@@ -4,17 +4,17 @@ from typing import Annotated
 
 import httpx
 from fastapi import Depends, Request
-from letsbuilda.pypi import PyPIServices
 
 from mainframe.authorization_header_elements import get_bearer_token
 from mainframe.json_web_token import AuthenticationData, CFJsonWebToken, JsonWebToken
+from mainframe.pypi import PyPIClient
 from mainframe.rules import Rules
 
 
 @cache
-def get_pypi_client() -> PyPIServices:
+def get_pypi_client() -> PyPIClient:
     http_client = httpx.Client()
-    return PyPIServices(http_client)
+    return PyPIClient(http_client)
 
 
 def get_httpx_client(request: Request) -> httpx.Client:

--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -7,9 +7,6 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlalchemy import paginate
-from letsbuilda.pypi import Package as PyPIPackage
-from letsbuilda.pypi import PyPIServices
-from letsbuilda.pypi.exceptions import PackageNotFoundError
 from sqlalchemy import select, tuple_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
@@ -27,6 +24,7 @@ from mainframe.models.schemas import (
     PackageSpecifier,
     QueuePackageResponse,
 )
+from mainframe.pypi import PackageMetadata, PackageNotFoundError, PyPIClient
 
 router = APIRouter(tags=["package"])
 logger: structlog.stdlib.BoundLogger = structlog.get_logger()
@@ -227,11 +225,13 @@ def _deduplicate_packages(packages: list[PackageSpecifier], session: Session) ->
     return name_ver - {(scan.name, scan.version) for scan in scalars.all()}
 
 
-def _get_packages_metadata(pypi_client: PyPIServices, packages_to_check: set[tuple[str, str]]) -> Iterable[PyPIPackage]:
+def _get_packages_metadata(
+    pypi_client: PyPIClient, packages_to_check: set[tuple[str, str]]
+) -> Iterable[PackageMetadata]:
     if not packages_to_check:
         return
 
-    def _get_package_metadata(package: tuple[str, str]) -> PyPIPackage | None:
+    def _get_package_metadata(package: tuple[str, str]) -> PackageMetadata | None:
         try:
             return pypi_client.get_package_metadata(*package)
         except PackageNotFoundError:
@@ -255,20 +255,18 @@ def batch_queue_package(
     packages: list[PackageSpecifier],
     session: Annotated[Session, Depends(get_db)],
     auth: Annotated[AuthenticationData, Depends(validate_token)],
-    pypi_client: Annotated[PyPIServices, Depends(get_pypi_client)],
+    pypi_client: Annotated[PyPIClient, Depends(get_pypi_client)],
 ) -> None:
     with session, session.begin():
         packages_to_check = _deduplicate_packages(packages, session)
 
         for package_metadata in _get_packages_metadata(pypi_client, packages_to_check):
             scan = Scan(
-                name=package_metadata.title,
-                version=package_metadata.releases[0].version,
+                name=package_metadata.name,
+                version=package_metadata.version,
                 status=Status.QUEUED,
                 queued_by=auth.subject,
-                download_urls=[
-                    DownloadURL(url=distribution.url) for distribution in package_metadata.releases[0].distributions
-                ],
+                download_urls=[DownloadURL(url=distribution.url) for distribution in package_metadata.distributions],
             )
 
             session.add(scan)
@@ -288,7 +286,7 @@ def queue_package(
     package: PackageSpecifier,
     session: Annotated[Session, Depends(get_db)],
     auth: Annotated[AuthenticationData, Depends(validate_token)],
-    pypi_client: Annotated[PyPIServices, Depends(get_pypi_client)],
+    pypi_client: Annotated[PyPIClient, Depends(get_pypi_client)],
 ) -> QueuePackageResponse:
     """Queue a package to be scanned when the next runner is available.
 
@@ -313,9 +311,7 @@ def queue_package(
         version=version,
         status=Status.QUEUED,
         queued_by=auth.subject,
-        download_urls=[
-            DownloadURL(url=distribution.url) for distribution in package_metadata.releases[0].distributions
-        ],
+        download_urls=[DownloadURL(url=distribution.url) for distribution in package_metadata.distributions],
     )
 
     try:

--- a/src/mainframe/pypi.py
+++ b/src/mainframe/pypi.py
@@ -18,9 +18,9 @@ PYPI_BASE_URL = "https://pypi.org/pypi"
 
 
 class PackageNotFoundError(Exception):
-    """Raised when a package (or a specific version of it) is not found on PyPI."""
+    """Raised when a package version is not found on PyPI."""
 
-    def __init__(self: Self, name: str, version: str | None = None) -> None:
+    def __init__(self: Self, name: str, version: str) -> None:
         self.name = name
         self.version = version
         super().__init__(f"'{name}' @ '{version}' not found on PyPI!")
@@ -60,12 +60,12 @@ class PyPIClient:
     def __init__(self: Self, http_client: httpx.Client) -> None:
         self.http_client = http_client
 
-    def get_package_metadata(self: Self, name: str, version: str | None = None) -> PackageMetadata:
-        """Fetch metadata for a package, optionally pinned to a specific version.
+    def get_package_metadata(self: Self, name: str, version: str) -> PackageMetadata:
+        """Fetch metadata for a specific version of a package.
 
         Args:
             name: The package name.
-            version: The package version. If omitted, the latest release is used.
+            version: The package version.
 
         Returns:
             The metadata for the requested package.
@@ -73,7 +73,7 @@ class PyPIClient:
         Raises:
             PackageNotFoundError: If the package or version does not exist on PyPI.
         """
-        url = f"{PYPI_BASE_URL}/{name}/{version}/json" if version is not None else f"{PYPI_BASE_URL}/{name}/json"
+        url = f"{PYPI_BASE_URL}/{name}/{version}/json"
 
         response = self.http_client.get(url)
         if response.status_code == HTTPStatus.NOT_FOUND:

--- a/src/mainframe/pypi.py
+++ b/src/mainframe/pypi.py
@@ -1,12 +1,4 @@
-"""A minimal in-house client for the PyPI JSON API.
-
-This replaces the third-party ``letsbuilda-pypi`` dependency. Only the handful
-of fields that mainframe actually consumes are modelled here; every other field
-in the PyPI response is ignored. Keeping the surface this small insulates us
-from the many under-documented quirks of the upstream API (fields that are
-nullable in practice but not in the docs, enum types with undocumented values,
-etc.) — if PyPI adds or changes a field we don't read, we simply don't care.
-"""
+"""Minimal client over PyPI JSON API."""
 
 from http import HTTPStatus
 from typing import Self

--- a/src/mainframe/pypi.py
+++ b/src/mainframe/pypi.py
@@ -43,7 +43,7 @@ class JSONResponse(BaseModel):
     """The shape of the PyPI JSON response, limited to what we parse."""
 
     info: Info
-    urls: list[Distribution] = Field(default_factory=list[Distribution])
+    urls: list[Distribution] = Field(default_factory=list)
 
 
 class PyPIClient:

--- a/src/mainframe/pypi.py
+++ b/src/mainframe/pypi.py
@@ -1,0 +1,88 @@
+"""A minimal in-house client for the PyPI JSON API.
+
+This replaces the third-party ``letsbuilda-pypi`` dependency. Only the handful
+of fields that mainframe actually consumes are modelled here; every other field
+in the PyPI response is ignored. Keeping the surface this small insulates us
+from the many under-documented quirks of the upstream API (fields that are
+nullable in practice but not in the docs, enum types with undocumented values,
+etc.) — if PyPI adds or changes a field we don't read, we simply don't care.
+"""
+
+from http import HTTPStatus
+from typing import Self
+
+import httpx
+from pydantic import BaseModel, Field
+
+PYPI_BASE_URL = "https://pypi.org/pypi"
+
+
+class PackageNotFoundError(Exception):
+    """Raised when a package (or a specific version of it) is not found on PyPI."""
+
+    def __init__(self: Self, name: str, version: str | None = None) -> None:
+        self.name = name
+        self.version = version
+        super().__init__(f"'{name}' @ '{version}' not found on PyPI!")
+
+
+class Distribution(BaseModel):
+    """A single downloadable file (e.g. an sdist or wheel) for a release."""
+
+    url: str
+
+
+class PackageMetadata(BaseModel):
+    """The subset of PyPI package metadata that mainframe uses."""
+
+    name: str
+    version: str
+    distributions: list[Distribution]
+
+
+class _Info(BaseModel):
+    """The `info` object of the PyPI JSON response (only the fields we read)."""
+
+    name: str
+    version: str
+
+
+class _JSONResponse(BaseModel):
+    """The shape of the PyPI JSON response, limited to what we parse."""
+
+    info: _Info
+    urls: list[Distribution] = Field(default_factory=list[Distribution])
+
+
+class PyPIClient:
+    """A minimal synchronous client for the PyPI JSON API."""
+
+    def __init__(self: Self, http_client: httpx.Client) -> None:
+        self.http_client = http_client
+
+    def get_package_metadata(self: Self, name: str, version: str | None = None) -> PackageMetadata:
+        """Fetch metadata for a package, optionally pinned to a specific version.
+
+        Args:
+            name: The package name.
+            version: The package version. If omitted, the latest release is used.
+
+        Returns:
+            The metadata for the requested package.
+
+        Raises:
+            PackageNotFoundError: If the package or version does not exist on PyPI.
+        """
+        url = f"{PYPI_BASE_URL}/{name}/{version}/json" if version is not None else f"{PYPI_BASE_URL}/{name}/json"
+
+        response = self.http_client.get(url)
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            raise PackageNotFoundError(name, version)
+        response.raise_for_status()
+
+        data = _JSONResponse.model_validate(response.json())
+        return PackageMetadata(
+            name=data.info.name,
+            version=data.info.version,
+            distributions=data.urls,
+        )

--- a/src/mainframe/pypi.py
+++ b/src/mainframe/pypi.py
@@ -40,17 +40,17 @@ class PackageMetadata(BaseModel):
     distributions: list[Distribution]
 
 
-class _Info(BaseModel):
+class Info(BaseModel):
     """The `info` object of the PyPI JSON response (only the fields we read)."""
 
     name: str
     version: str
 
 
-class _JSONResponse(BaseModel):
+class JSONResponse(BaseModel):
     """The shape of the PyPI JSON response, limited to what we parse."""
 
-    info: _Info
+    info: Info
     urls: list[Distribution] = Field(default_factory=list[Distribution])
 
 
@@ -80,7 +80,7 @@ class PyPIClient:
             raise PackageNotFoundError(name, version)
         response.raise_for_status()
 
-        data = _JSONResponse.model_validate(response.json())
+        data = JSONResponse.model_validate(response.json())
         return PackageMetadata(
             name=data.info.name,
             version=data.info.version,

--- a/src/mainframe/server.py
+++ b/src/mainframe/server.py
@@ -10,7 +10,6 @@ import sentry_sdk
 from asgi_correlation_id import CorrelationIdMiddleware, correlation_id
 from fastapi import Depends, FastAPI
 from fastapi_pagination import add_pagination
-from letsbuilda.pypi import PyPIServices
 from prometheus_fastapi_instrumentator import Instrumentator
 from sentry_sdk.integrations.logging import LoggingIntegration
 from structlog_sentry import SentryProcessor
@@ -22,6 +21,7 @@ from mainframe.constants import GIT_SHA, Sentry, mainframe_settings
 from mainframe.dependencies import validate_token, validate_token_override
 from mainframe.endpoints import routers
 from mainframe.models.schemas import ServerMetadata
+from mainframe.pypi import PyPIClient
 from mainframe.rules import Rules, fetch_rules
 
 from . import __version__
@@ -56,7 +56,7 @@ sentry_sdk.init(
 async def lifespan(app_: FastAPI) -> AsyncGenerator[None, None]:
     """Load the state for the app."""
     http_client = httpx.Client()
-    pypi_client = PyPIServices(http_client)
+    pypi_client = PyPIClient(http_client)
     rules = fetch_rules(http_client)
 
     app_.state.rules = rules

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,14 +7,12 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
-from letsbuilda.pypi import PyPIServices
-from letsbuilda.pypi.models import Package
-from letsbuilda.pypi.models.models_package import Distribution, Release
 from sqlalchemy import Engine, create_engine, make_url, text
 from sqlalchemy.orm import Session, sessionmaker
 
 from mainframe.json_web_token import AuthenticationData
 from mainframe.models.orm import Base, Scan
+from mainframe.pypi import Distribution, PackageMetadata, PyPIClient
 from mainframe.rules import Rules
 
 from .test_data import data
@@ -98,15 +96,12 @@ def rules_state() -> Rules:
 
 
 @pytest.fixture(scope="session")
-def pypi_client() -> PyPIServices:
+def pypi_client() -> PyPIClient:
     http_client = httpx.Client()
-    pypi_client = PyPIServices(http_client)
+    pypi_client = PyPIClient(http_client)
 
-    def side_effect(name: str, version: str) -> Package:
-        return Package(
-            title=name,
-            releases=[Release(version=version, distributions=[Distribution(filename="test", url="test")])],
-        )
+    def side_effect(name: str, version: str) -> PackageMetadata:
+        return PackageMetadata(name=name, version=version, distributions=[Distribution(url="test")])
 
     pypi_client.get_package_metadata = MagicMock(side_effect=side_effect)
     return pypi_client

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,8 +4,6 @@ from typing import cast
 import pytest
 from fastapi import HTTPException, status
 from fastapi_pagination import Page
-from letsbuilda.pypi import PyPIServices
-from letsbuilda.pypi.exceptions import PackageNotFoundError
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
@@ -26,6 +24,7 @@ from mainframe.models.schemas import (
     PackageScanResultFail,
     PackageSpecifier,
 )
+from mainframe.pypi import PackageNotFoundError, PyPIClient
 from mainframe.rules import Rules
 
 
@@ -148,7 +147,7 @@ def test_handle_fail(db_session: Session, test_data: list[Scan], auth: Authentic
         assert all(scan.status != Status.QUEUED for scan in test_data)
 
 
-def test_batch_queue(db_session: Session, pypi_client: PyPIServices, auth: AuthenticationData):
+def test_batch_queue(db_session: Session, pypi_client: PyPIClient, auth: AuthenticationData):
     pack = PackageSpecifier(name="c", version="1.0.0")
     batch_queue_package([pack], db_session, auth, pypi_client)
 
@@ -157,7 +156,7 @@ def test_batch_queue(db_session: Session, pypi_client: PyPIServices, auth: Authe
     assert (pack.name, pack.version) in existing_packages
 
 
-def test_batch_queue_empty_packages(db_session: Session, pypi_client: PyPIServices, auth: AuthenticationData):
+def test_batch_queue_empty_packages(db_session: Session, pypi_client: PyPIClient, auth: AuthenticationData):
     with db_session.begin():
         before = sorted((s.name, s.version) for s in db_session.scalars(select(Scan)))
     batch_queue_package([], db_session, auth, pypi_client)
@@ -178,7 +177,7 @@ def test_deduplicate_packages(test_data: list[Scan], packages: list[PackageSpeci
 
 def test_batch_queue_nonexistent_package(
     db_session: Session,
-    pypi_client: PyPIServices,
+    pypi_client: PyPIClient,
     auth: AuthenticationData,
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -196,7 +195,7 @@ def test_batch_queue_nonexistent_package(
     assert ("c", "1.0.0") not in existing_packages
 
 
-def test_queue(db_session: Session, pypi_client: PyPIServices, auth: AuthenticationData):
+def test_queue(db_session: Session, pypi_client: PyPIClient, auth: AuthenticationData):
     package = PackageSpecifier(name="c", version="1.0.0")
     query = select(Scan).where(Scan.name == package.name).where(Scan.version == package.version)
 
@@ -211,7 +210,7 @@ def test_queue(db_session: Session, pypi_client: PyPIServices, auth: Authenticat
 
 def test_queue_nonexistent_package(
     db_session: Session,
-    pypi_client: PyPIServices,
+    pypi_client: PyPIClient,
     auth: AuthenticationData,
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -232,7 +231,7 @@ def test_queue_nonexistent_package(
         assert db_session.scalar(query) is None
 
 
-def test_queue_duplicate_package(db_session: Session, pypi_client: PyPIServices, auth: AuthenticationData):
+def test_queue_duplicate_package(db_session: Session, pypi_client: PyPIClient, auth: AuthenticationData):
     package = PackageSpecifier(name="c", version="1.0.0")
 
     queue_package(package, db_session, auth, pypi_client)

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -46,6 +46,56 @@ def test_get_package_metadata_ignores_unmodelled_and_missing_fields():
     assert metadata.distributions == []
 
 
+def test_get_package_metadata_ignores_extra_pypi_fields():
+    """Regression: unknown fields PyPI may add must be ignored, not crash parsing.
+
+    The real PyPI JSON response carries many more keys than we model, at the
+    top level and nested inside ``info`` and each ``urls`` entry. This mirrors
+    a realistic response (the fields we use plus a representative sample of
+    extras) and confirms the extras are silently dropped while the fields we
+    care about still parse correctly.
+    """
+    payload = {
+        "info": {
+            "name": "requests",
+            "version": "2.32.3",
+            # Fields PyPI returns that we deliberately don't model.
+            "author": "Kenneth Reitz",
+            "summary": "Python HTTP for Humans.",
+            "requires_python": ">=3.8",
+            "yanked": False,
+            "classifiers": ["Programming Language :: Python :: 3"],
+            "project_urls": {"Homepage": "https://requests.readthedocs.io"},
+        },
+        "urls": [
+            {
+                "url": "https://files.pythonhosted.org/requests-2.32.3.tar.gz",
+                # Extra per-distribution fields we don't model.
+                "filename": "requests-2.32.3.tar.gz",
+                "packagetype": "sdist",
+                "size": 131218,
+                "yanked": False,
+                "digests": {"sha256": "deadbeef"},
+                "upload_time_iso_8601": "2024-05-29T15:37:49.000000Z",
+            },
+        ],
+        # A brand-new top-level key PyPI might add in the future.
+        "vulnerabilities": [],
+        "some_future_field": {"nested": "value"},
+    }
+    http_client = _make_mock_http_client(httpx.Response(HTTPStatus.OK, json=payload))
+
+    metadata = PyPIClient(http_client).get_package_metadata("requests", "2.32.3")
+
+    # The fields we care about parse correctly...
+    assert metadata.name == "requests"
+    assert metadata.version == "2.32.3"
+    assert [d.url for d in metadata.distributions] == ["https://files.pythonhosted.org/requests-2.32.3.tar.gz"]
+    # ...and none of the unmodelled extras leak onto our models.
+    assert "size" not in metadata.distributions[0].model_dump()
+    assert set(metadata.model_dump()) == {"name", "version", "distributions"}
+
+
 def test_get_package_metadata_not_found():
     http_client = _make_mock_http_client(httpx.Response(HTTPStatus.NOT_FOUND))
 

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -36,14 +36,6 @@ def test_get_package_metadata_with_version():
     ]
 
 
-def test_get_package_metadata_without_version():
-    http_client = _make_mock_http_client(httpx.Response(HTTPStatus.OK, json=SAMPLE_RESPONSE))
-
-    PyPIClient(http_client).get_package_metadata("requests")
-
-    http_client.get.assert_called_once_with("https://pypi.org/pypi/requests/json")
-
-
 def test_get_package_metadata_ignores_unmodelled_and_missing_fields():
     """Extra fields are ignored and a release with no distributions is tolerated."""
     payload = {"info": {"name": "empty", "version": "1.0.0", "yanked": None}, "extra": "ignored"}

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -1,0 +1,64 @@
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from mainframe.pypi import PackageNotFoundError, PyPIClient
+
+SAMPLE_RESPONSE = {
+    "info": {"name": "requests", "version": "2.32.3"},
+    "urls": [
+        {"url": "https://files.pythonhosted.org/requests-2.32.3.tar.gz", "filename": "requests-2.32.3.tar.gz"},
+        {"url": "https://files.pythonhosted.org/requests-2.32.3-py3-none-any.whl"},
+    ],
+}
+
+
+def _make_mock_http_client(response: httpx.Response) -> MagicMock:
+    response.request = httpx.Request("GET", "https://pypi.org/pypi/test/json")
+    http_client = MagicMock(spec=httpx.Client)
+    http_client.get.return_value = response
+    return http_client
+
+
+def test_get_package_metadata_with_version():
+    http_client = _make_mock_http_client(httpx.Response(HTTPStatus.OK, json=SAMPLE_RESPONSE))
+
+    metadata = PyPIClient(http_client).get_package_metadata("requests", "2.32.3")
+
+    http_client.get.assert_called_once_with("https://pypi.org/pypi/requests/2.32.3/json")
+    assert metadata.name == "requests"
+    assert metadata.version == "2.32.3"
+    assert [d.url for d in metadata.distributions] == [
+        "https://files.pythonhosted.org/requests-2.32.3.tar.gz",
+        "https://files.pythonhosted.org/requests-2.32.3-py3-none-any.whl",
+    ]
+
+
+def test_get_package_metadata_without_version():
+    http_client = _make_mock_http_client(httpx.Response(HTTPStatus.OK, json=SAMPLE_RESPONSE))
+
+    PyPIClient(http_client).get_package_metadata("requests")
+
+    http_client.get.assert_called_once_with("https://pypi.org/pypi/requests/json")
+
+
+def test_get_package_metadata_ignores_unmodelled_and_missing_fields():
+    """Extra fields are ignored and a release with no distributions is tolerated."""
+    payload = {"info": {"name": "empty", "version": "1.0.0", "yanked": None}, "extra": "ignored"}
+    http_client = _make_mock_http_client(httpx.Response(HTTPStatus.OK, json=payload))
+
+    metadata = PyPIClient(http_client).get_package_metadata("empty", "1.0.0")
+
+    assert metadata.distributions == []
+
+
+def test_get_package_metadata_not_found():
+    http_client = _make_mock_http_client(httpx.Response(HTTPStatus.NOT_FOUND))
+
+    with pytest.raises(PackageNotFoundError) as exc_info:
+        PyPIClient(http_client).get_package_metadata("does-not-exist", "9.9.9")
+
+    assert exc_info.value.name == "does-not-exist"
+    assert exc_info.value.version == "9.9.9"

--- a/uv.lock
+++ b/uv.lock
@@ -297,7 +297,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastapi-pagination" },
     { name = "httpx" },
-    { name = "letsbuilda-pypi" },
     { name = "prometheus-client" },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg2-binary" },
@@ -337,7 +336,6 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "fastapi-pagination", specifier = "==0.15.8" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "letsbuilda-pypi", specifier = "==6.0.1" },
     { name = "prometheus-client", specifier = "==0.24.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = "==8.0.1" },
     { name = "psycopg2-binary", specifier = "==2.9.11" },
@@ -445,7 +443,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
     { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
     { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
     { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
     { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
     { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
     { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
@@ -550,20 +550,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "letsbuilda-pypi"
-version = "6.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "xmltodict" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/81/42/a028d4aa81bb2917c2062d1d9dc5cc7726c55c03ad9c4c19c704b1a00ff8/letsbuilda_pypi-6.0.1.tar.gz", hash = "sha256:ed0263971d41751bb75bbcdaaf27b622ee521500ce53ed76d76364eaa2ec525e", size = 8729, upload-time = "2026-07-07T23:20:43.368Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/32/58857e2ae568fde16768a7b96798fe038bda3aa75f88d93590be4116a5dd/letsbuilda_pypi-6.0.1-py3-none-any.whl", hash = "sha256:a8ef1fb4477321a38e3b0b986af86f21887d2f36afa15e6d31c25e6601c31c17", size = 8165, upload-time = "2026-07-07T23:20:42.267Z" },
 ]
 
 [[package]]
@@ -1295,13 +1281,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
     { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
-]
-
-[[package]]
-name = "xmltodict"
-version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]


### PR DESCRIPTION
Since we're only using a very small subset of information from the PyPI JSON API, it will be easier to maintain an in-house version. We create `pypi.py`, which acts as a simple helper over the JSON API.