### PR TITLE
Accept rotated Cloudflare signing keys safely

### DIFF
--- a/src/mainframe/json_web_token.py
+++ b/src/mainframe/json_web_token.py
@@ -1,7 +1,9 @@
 import datetime as dt
+import time
 from dataclasses import dataclass
 from functools import cache
-from threading import Lock
+from json import JSONDecodeError
+from threading import Condition
 from typing import Any, Self
 
 import jwt
@@ -13,28 +15,155 @@ from mainframe.custom_exceptions import (
 )
 
 
-class CachedPyJWKClient(jwt.PyJWKClient):
-    """Refresh the JWKS on a fixed schedule, independent of requested key IDs."""
+class CoalescingPyJWKClient(jwt.PyJWKClient):
+    """Refresh stale signing keys without allowing a request-driven stampede."""
 
-    def __init__(self, uri: str, lifespan: float = 10.0) -> None:
-        super().__init__(uri, lifespan=lifespan)
-        self._cache_lock = Lock()
+    _missing_key_limit = 128
+
+    def __init__(
+        self,
+        uri: str,
+        refresh_interval: float = 1.0,
+        lifespan: float = 300.0,
+    ) -> None:
+        super().__init__(uri, lifespan=lifespan, timeout=5)
+        self._refresh_interval = refresh_interval
+        self._refresh_condition = Condition()
+        self._refreshing = False
+        self._refreshing_kid: str | None = None
+        self._refresh_generation = 0
+        self._last_refresh_error: tuple[bool, str] | None = None
+        self._next_refresh_at = 0.0
+        self._known_key_ids: frozenset[str] = frozenset()
+        self._missing_kids: dict[str, None] = {}
+
+    @staticmethod
+    def _missing_key_error() -> jwt.exceptions.PyJWKClientError:
+        return jwt.exceptions.PyJWKClientError("Unable to find a matching signing key")
+
+    def _record_keys(self, signing_keys: list[jwt.PyJWK]) -> None:
+        key_ids = frozenset(key.key_id for key in signing_keys if key.key_id is not None)
+        if self._known_key_ids and key_ids != self._known_key_ids:
+            self._missing_kids.clear()
+        self._known_key_ids = key_ids
+
+    def _record_missing_key(self, kid: str) -> None:
+        if len(self._missing_kids) >= self._missing_key_limit:
+            self._missing_kids.pop(next(iter(self._missing_kids)))
+        self._missing_kids[kid] = None
+
+    def _cached_signing_keys(self) -> tuple[list[jwt.PyJWK], bool]:
+        jwk_set_cache = self.jwk_set_cache
+        had_cached_jwks = jwk_set_cache is not None and jwk_set_cache.get() is not None
+        signing_keys = self.get_signing_keys()
+        self._record_keys(signing_keys)
+        return signing_keys, had_cached_jwks
+
+    def _wait_for_refresh(self, timeout: float | None = None) -> None:
+        self._refresh_condition.wait(timeout)
+
+    def _claim_refresh(self, kid: str) -> bool:
+        target_generation = self._refresh_generation + 1
+        if self._refreshing and self._refreshing_kid != kid:
+            target_generation += 1
+
+        while self._refresh_generation < target_generation:
+            if self._refreshing:
+                self._wait_for_refresh()
+                continue
+
+            refresh_delay = self._next_refresh_at - time.monotonic()
+            if refresh_delay > 0:
+                self._wait_for_refresh(refresh_delay)
+                continue
+
+            self._refreshing = True
+            self._refreshing_kid = kid
+            return True
+
+        return False
+
+    def _refresh_signing_keys(
+        self,
+    ) -> tuple[list[jwt.PyJWK], jwt.exceptions.PyJWKClientError | None]:
+        jwk_set_cache = self.jwk_set_cache
+        cached_jwk_set = jwk_set_cache.get() if jwk_set_cache is not None else None
+        signing_keys: list[jwt.PyJWK] = []
+        refresh_error: jwt.exceptions.PyJWKClientError | None = None
+        try:
+            signing_keys = self.get_signing_keys(refresh=True)
+        except (jwt.exceptions.PyJWTError, JSONDecodeError) as err:
+            if isinstance(err, JSONDecodeError):
+                refresh_error = jwt.exceptions.PyJWKClientConnectionError("The JWKS endpoint returned invalid JSON")
+            elif isinstance(err, jwt.exceptions.PyJWKClientError):
+                refresh_error = err
+            else:
+                refresh_error = jwt.exceptions.PyJWKClientError(str(err))
+            if jwk_set_cache is not None and cached_jwk_set is not None:
+                jwk_set_cache.put(cached_jwk_set)
+        finally:
+            with self._refresh_condition:
+                self._refreshing = False
+                self._refreshing_kid = None
+                self._refresh_generation += 1
+                if refresh_error is None:
+                    self._last_refresh_error = None
+                else:
+                    is_connection_error = isinstance(refresh_error, jwt.exceptions.PyJWKClientConnectionError)
+                    self._last_refresh_error = (is_connection_error, str(refresh_error))
+                self._next_refresh_at = time.monotonic() + self._refresh_interval
+                if signing_keys:
+                    self._record_keys(signing_keys)
+                self._refresh_condition.notify_all()
+
+        return signing_keys, refresh_error
+
+    def _resolved_key(self, signing_keys: list[jwt.PyJWK], kid: str) -> jwt.PyJWK:
+        signing_key = self.match_kid(signing_keys, kid)
+        if signing_key is None:
+            self._record_missing_key(kid)
+            raise self._missing_key_error()
+        return signing_key
+
+    def _resolved_key_after_shared_refresh(self, kid: str) -> jwt.PyJWK:
+        with self._refresh_condition:
+            if self._last_refresh_error is not None:
+                is_connection_error, message = self._last_refresh_error
+                if is_connection_error:
+                    raise jwt.exceptions.PyJWKClientConnectionError(message)
+                raise jwt.exceptions.PyJWKClientError(message)
+            signing_keys = self.get_signing_keys()
+            self._record_keys(signing_keys)
+            return self._resolved_key(signing_keys, kid)
 
     def get_signing_key(self, kid: str) -> jwt.PyJWK:
-        with self._cache_lock:
-            signing_key = self.match_kid(self.get_signing_keys(), kid)
+        if not kid:
+            raise self._missing_key_error()
 
-        if signing_key is None:
-            message = "Unable to find a matching signing key"
-            raise jwt.exceptions.PyJWKClientError(message)
+        with self._refresh_condition:
+            signing_keys, had_cached_jwks = self._cached_signing_keys()
+            signing_key = self.match_kid(signing_keys, kid)
+            if signing_key is not None:
+                return signing_key
+            if not had_cached_jwks:
+                return self._resolved_key(signing_keys, kid)
+            if kid in self._missing_kids:
+                raise self._missing_key_error()
+            perform_refresh = self._claim_refresh(kid)
 
-        return signing_key
+        if not perform_refresh:
+            return self._resolved_key_after_shared_refresh(kid)
+
+        signing_keys, refresh_error = self._refresh_signing_keys()
+        if refresh_error is not None:
+            raise refresh_error
+        return self._resolved_key(signing_keys, kid)
 
 
 @cache
 def get_jwks_client(jwks_uri: str) -> jwt.PyJWKClient:
     """Return a shared JWKS client with PyJWT's key-set cache."""
-    return CachedPyJWKClient(jwks_uri)
+    return CoalescingPyJWKClient(jwks_uri)
 
 
 @dataclass

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,9 +1,14 @@
 import datetime as dt
 import io
 import json
+from base64 import urlsafe_b64encode
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
+from threading import Event
 from typing import cast
 from unittest.mock import Mock
+from urllib.error import URLError
 
 import anyio
 import httpx
@@ -23,7 +28,7 @@ from mainframe.custom_exceptions import (
 from mainframe.dependencies import validate_token
 from mainframe.json_web_token import (
     AuthenticationData,
-    CachedPyJWKClient,
+    CoalescingPyJWKClient,
     JsonWebToken,
     get_jwks_client,
 )
@@ -56,6 +61,13 @@ RSA_JWK = {
     ),
     "use": "sig",
 }
+
+
+def _unsigned_token(kid: str) -> str:
+    header = json.dumps({"alg": "RS256", "kid": kid}, separators=(",", ":")).encode()
+    encoded_header = urlsafe_b64encode(header).rstrip(b"=").decode()
+    encoded_payload = urlsafe_b64encode(b"{}").rstrip(b"=").decode()
+    return f"{encoded_header}.{encoded_payload}."
 
 
 def _request(headers: dict[str, str]) -> Request:
@@ -127,7 +139,7 @@ def test_get_jwks_client_is_cached(monkeypatch: pytest.MonkeyPatch):
     get_jwks_client.cache_clear()
     jwks_client = Mock()
     constructor = Mock(return_value=jwks_client)
-    monkeypatch.setattr("mainframe.json_web_token.CachedPyJWKClient", constructor)
+    monkeypatch.setattr("mainframe.json_web_token.CoalescingPyJWKClient", constructor)
 
     try:
         assert get_jwks_client("https://access.example.test/certs") is jwks_client
@@ -138,9 +150,9 @@ def test_get_jwks_client_is_cached(monkeypatch: pytest.MonkeyPatch):
     constructor.assert_called_once_with("https://access.example.test/certs")
 
 
-def test_unknown_kid_cannot_force_jwks_refresh(monkeypatch: pytest.MonkeyPatch):
+def test_repeated_unknown_kid_gets_one_bounded_refresh(monkeypatch: pytest.MonkeyPatch):
     jwk_set = {"keys": [{**RSA_JWK, "kid": "cloudflare-key"}]}
-    jwks_client = CachedPyJWKClient("https://access.example.test/certs")
+    jwks_client = CoalescingPyJWKClient("https://access.example.test/certs")
 
     def fetch_jwks(_request: object, *, timeout: float, context: object) -> io.BytesIO:
         del timeout, context
@@ -148,25 +160,24 @@ def test_unknown_kid_cannot_force_jwks_refresh(monkeypatch: pytest.MonkeyPatch):
 
     fetch = Mock(side_effect=fetch_jwks)
     monkeypatch.setattr("jwt.jwks_client.urllib.request.urlopen", fetch)
+    known_token = _unsigned_token("cloudflare-key")
     header_segment = "eyJhbGciOiJSUzI1NiIsImtpZCI6InVua25vd24ta2V5In0"
     payload_segment = "e30"
     token = f"{header_segment}.{payload_segment}."
 
+    assert jwks_client.get_signing_key_from_jwt(known_token).key_id == "cloudflare-key"
     for _ in range(2):
         with pytest.raises(jwt.exceptions.PyJWKClientError):
             jwks_client.get_signing_key_from_jwt(token)
 
-    assert fetch.call_count == 1
+    assert fetch.call_count == 2
 
 
-def test_signing_key_rotation_is_loaded_after_cache_expiry(monkeypatch: pytest.MonkeyPatch):
+def test_signing_key_rotation_refreshes_before_cache_expiry(monkeypatch: pytest.MonkeyPatch):
     old_jwk = {**RSA_JWK, "kid": "old-key"}
     new_jwk = {**old_jwk, "kid": "new-key"}
     jwk_sets = iter([{"keys": [old_jwk]}, {"keys": [old_jwk, new_jwk]}])
-    now = [100.0]
-    monkeypatch.setattr("jwt.api_jwk.time.monotonic", lambda: now[0])
-    monkeypatch.setattr("jwt.jwk_set_cache.time.monotonic", lambda: now[0])
-    jwks_client = CachedPyJWKClient("https://access.example.test/certs")
+    jwks_client = CoalescingPyJWKClient("https://access.example.test/certs")
 
     def fetch_jwks(_request: object, *, timeout: float, context: object) -> io.BytesIO:
         del timeout, context
@@ -181,13 +192,161 @@ def test_signing_key_rotation_is_loaded_after_cache_expiry(monkeypatch: pytest.M
     new_token = f"{new_header_segment}.{payload_segment}."
 
     assert jwks_client.get_signing_key_from_jwt(old_token).key_id == "old-key"
-    with pytest.raises(jwt.exceptions.PyJWKClientError):
-        jwks_client.get_signing_key_from_jwt(new_token)
-
-    now[0] += 11
-
     assert jwks_client.get_signing_key_from_jwt(new_token).key_id == "new-key"
     assert fetch.call_count == 2
+
+
+def test_unknown_kid_does_not_block_later_rotation(monkeypatch: pytest.MonkeyPatch):
+    old_jwk = {**RSA_JWK, "kid": "old-key"}
+    new_jwk = {**old_jwk, "kid": "new-key"}
+    jwk_sets: Iterator[dict[str, list[dict[str, str | list[str]]]]] = iter(
+        [
+            {"keys": [old_jwk]},
+            {"keys": [old_jwk]},
+            {"keys": [old_jwk, new_jwk]},
+        ]
+    )
+    now = [100.0]
+    monkeypatch.setattr("mainframe.json_web_token.time.monotonic", lambda: now[0])
+    jwks_client = CoalescingPyJWKClient("https://access.example.test/certs")
+
+    def wait_for_refresh(timeout: float | None = None) -> None:
+        assert timeout is not None
+        now[0] += timeout
+
+    monkeypatch.setattr(jwks_client, "_wait_for_refresh", wait_for_refresh)
+
+    def fetch_jwks(_request: object, *, timeout: float, context: object) -> io.BytesIO:
+        del timeout, context
+        return io.BytesIO(json.dumps(next(jwk_sets)).encode())
+
+    fetch = Mock(side_effect=fetch_jwks)
+    monkeypatch.setattr("jwt.jwks_client.urllib.request.urlopen", fetch)
+    old_token = _unsigned_token("old-key")
+    unknown_token = _unsigned_token("unknown-key")
+    new_token = _unsigned_token("new-key")
+
+    assert jwks_client.get_signing_key_from_jwt(old_token).key_id == "old-key"
+    with pytest.raises(jwt.exceptions.PyJWKClientError):
+        jwks_client.get_signing_key_from_jwt(unknown_token)
+
+    assert jwks_client.get_signing_key_from_jwt(new_token).key_id == "new-key"
+    assert fetch.call_count == 3
+
+
+def test_failed_refresh_does_not_block_later_rotation(monkeypatch: pytest.MonkeyPatch):
+    old_jwk = {**RSA_JWK, "kid": "old-key"}
+    new_jwk = {**old_jwk, "kid": "new-key"}
+    responses = iter(
+        [
+            io.BytesIO(json.dumps({"keys": [old_jwk]}).encode()),
+            URLError("JWKS unavailable"),
+            io.BytesIO(json.dumps({"keys": [old_jwk, new_jwk]}).encode()),
+        ]
+    )
+    now = [100.0]
+    monkeypatch.setattr("mainframe.json_web_token.time.monotonic", lambda: now[0])
+    jwks_client = CoalescingPyJWKClient("https://access.example.test/certs")
+
+    def wait_for_refresh(timeout: float | None = None) -> None:
+        assert timeout is not None
+        now[0] += timeout
+
+    monkeypatch.setattr(jwks_client, "_wait_for_refresh", wait_for_refresh)
+
+    def fetch_jwks(_request: object, *, timeout: float, context: object) -> io.BytesIO:
+        del timeout, context
+        response = next(responses)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    fetch = Mock(side_effect=fetch_jwks)
+    monkeypatch.setattr("jwt.jwks_client.urllib.request.urlopen", fetch)
+    old_token = _unsigned_token("old-key")
+    unknown_token = _unsigned_token("unknown-key")
+    new_token = _unsigned_token("new-key")
+
+    assert jwks_client.get_signing_key_from_jwt(old_token).key_id == "old-key"
+    with pytest.raises(jwt.exceptions.PyJWKClientConnectionError):
+        jwks_client.get_signing_key_from_jwt(unknown_token)
+
+    assert jwks_client.get_signing_key_from_jwt(new_token).key_id == "new-key"
+    assert fetch.call_count == 3
+
+
+def test_invalid_jwks_refresh_preserves_cached_keys(monkeypatch: pytest.MonkeyPatch):
+    old_jwk = {**RSA_JWK, "kid": "old-key"}
+    new_jwk = {**old_jwk, "kid": "new-key"}
+    empty_keys: list[dict[str, str | list[str]]] = []
+    jwk_sets: Iterator[dict[str, list[dict[str, str | list[str]]]]] = iter(
+        [
+            {"keys": [old_jwk]},
+            {"keys": empty_keys},
+            {"keys": [old_jwk, new_jwk]},
+        ]
+    )
+    now = [100.0]
+    monkeypatch.setattr("mainframe.json_web_token.time.monotonic", lambda: now[0])
+    jwks_client = CoalescingPyJWKClient("https://access.example.test/certs")
+
+    def wait_for_refresh(timeout: float | None = None) -> None:
+        assert timeout is not None
+        now[0] += timeout
+
+    monkeypatch.setattr(jwks_client, "_wait_for_refresh", wait_for_refresh)
+
+    def fetch_jwks(_request: object, *, timeout: float, context: object) -> io.BytesIO:
+        del timeout, context
+        return io.BytesIO(json.dumps(next(jwk_sets)).encode())
+
+    fetch = Mock(side_effect=fetch_jwks)
+    monkeypatch.setattr("jwt.jwks_client.urllib.request.urlopen", fetch)
+    old_token = _unsigned_token("old-key")
+    unknown_token = _unsigned_token("unknown-key")
+    new_token = _unsigned_token("new-key")
+
+    assert jwks_client.get_signing_key_from_jwt(old_token).key_id == "old-key"
+    with pytest.raises(jwt.exceptions.PyJWKClientError):
+        jwks_client.get_signing_key_from_jwt(unknown_token)
+
+    assert jwks_client.get_signing_key_from_jwt(old_token).key_id == "old-key"
+    assert jwks_client.get_signing_key_from_jwt(new_token).key_id == "new-key"
+    assert fetch.call_count == 3
+
+
+def test_concurrent_unknown_kid_requests_share_refresh(monkeypatch: pytest.MonkeyPatch):
+    jwk_set = {"keys": [{**RSA_JWK, "kid": "cloudflare-key"}]}
+    jwks_client = CoalescingPyJWKClient("https://access.example.test/certs")
+    refresh_started = Event()
+    release_refresh = Event()
+    fetch_count = 0
+
+    def fetch_jwks(_request: object, *, timeout: float, context: object) -> io.BytesIO:
+        nonlocal fetch_count
+        del timeout, context
+        fetch_count += 1
+        if fetch_count == 2:
+            refresh_started.set()
+            assert release_refresh.wait(timeout=2)
+        return io.BytesIO(json.dumps(jwk_set).encode())
+
+    monkeypatch.setattr("jwt.jwks_client.urllib.request.urlopen", fetch_jwks)
+    known_token = _unsigned_token("cloudflare-key")
+    unknown_token = _unsigned_token("unknown-key")
+    assert jwks_client.get_signing_key_from_jwt(known_token).key_id == "cloudflare-key"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(jwks_client.get_signing_key_from_jwt, unknown_token)
+        assert refresh_started.wait(timeout=2)
+        second = executor.submit(jwks_client.get_signing_key_from_jwt, unknown_token)
+        release_refresh.set()
+        with pytest.raises(jwt.exceptions.PyJWKClientError):
+            first.result(timeout=2)
+        with pytest.raises(jwt.exceptions.PyJWKClientError):
+            second.result(timeout=2)
+
+    assert fetch_count == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- coordinate JWKS refreshes across concurrent requests
- accept newly rotated Cloudflare signing keys without waiting for cache expiry
- preserve the last known-good key set across temporary refresh failures
- add focused rotation, recovery, and concurrency regression coverage

## Validation

- `ruff format`
- `ruff check`
- `pyright` (strict; zero warnings)
- `ty check`
- `pytest` (150 passed)
- `prek run --all-files`
- `zizmor --pedantic .github/workflows`
