### PR TITLE
Normalize queue timestamps to UTC

### DIFF
--- a/src/mainframe/queue_monitor.py
+++ b/src/mainframe/queue_monitor.py
@@ -41,6 +41,8 @@ def read_queue_status(session: Session, *, now: dt.datetime, job_timeout: int) -
     oldest_queued_at = cast("dt.datetime | None", row[4])
     oldest_age_seconds = None
     if oldest_queued_at is not None:
+        if oldest_queued_at.tzinfo is None:
+            oldest_queued_at = oldest_queued_at.replace(tzinfo=dt.UTC)
         oldest_age_seconds = max(0, int((now - oldest_queued_at).total_seconds()))
 
     return QueueStatus(

--- a/tests/test_queue_monitor.py
+++ b/tests/test_queue_monitor.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException, status
@@ -85,6 +86,18 @@ def test_queue_status_handles_an_empty_queue(db_session: Session) -> None:
     assert snapshot.stranded == 0
     assert snapshot.oldest_queued_at is None
     assert snapshot.oldest_age_seconds is None
+
+
+def test_queue_status_normalizes_a_naive_database_timestamp() -> None:
+    now = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    session = MagicMock(spec=Session)
+    oldest_queued_at = (now - dt.timedelta(minutes=5)).replace(tzinfo=None)
+    session.execute.return_value.one.return_value = (1, 0, 0, 0, oldest_queued_at)
+
+    snapshot = read_queue_status(session, now=now, job_timeout=120)
+
+    assert snapshot.oldest_queued_at == now - dt.timedelta(minutes=5)
+    assert snapshot.oldest_age_seconds == 300
 
 
 def test_queue_monitor_caches_latest_snapshot(db_session: Session, engine: Engine) -> None:


### PR DESCRIPTION
## Summary

- normalize legacy timezone-naive queue timestamps to UTC before calculating queue age
- return a UTC-aware oldest queue timestamp from the cached snapshot
- cover the staging data shape with a regression test

## Staging finding

The initial queue observability rollout exposed that the deployed database schema stores `queued_at` as `timestamp without time zone`, despite the ORM declaring a timezone-aware type. PostgreSQL therefore returned a naive aggregate timestamp and every queue monitor refresh raised:

```text
TypeError: can't subtract offset-naive and offset-aware datetimes
```

The main API remained available, but `/queue-status` could not obtain an initial snapshot.

## Verification

- 152 tests passed
- 100% statement coverage
- pyright: 0 errors, warnings, or information diagnostics
- Ruff lint and format checks passed
- all pre-commit hooks passed
