### PR TITLE
Expose durable rule performance metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-executables-have-shebangs
@@ -45,7 +45,7 @@ repos:
           - pyi
 
   - repo: https://github.com/hadolint/hadolint
-    rev: c3dc18df7a501f02a560a2cc7ba3c69a85ca01d3  # frozen: v2.13.1-beta
+    rev: 57e1618d78fd469a92c1e584e8c9313024656623  # frozen: v2.14.0
     hooks:
       - id: hadolint
         args:
@@ -53,12 +53,12 @@ repos:
           - error
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 54da05914997e6b04e4db33ed6757d744984c68b  # frozen: 0.33.2
+    rev: 5030dca3047414c338091455ac41803200ec1f0f  # frozen: 0.37.3
     hooks:
       - id: check-github-workflows
 
   - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: 23eab0f0eedcbedebff420f5fdfb284744adc7b3  # frozen: v0.9.3
+    rev: ade0f95ddcf661c697d4670d2cfcbe95d0048a0a  # frozen: v0.9.3
     hooks:
       - id: taplo-format
       - id: taplo-lint
@@ -72,7 +72,7 @@ repos:
         files: ^pyproject\.toml$
 
   - repo: https://github.com/lyz-code/yamlfix
-    rev: 8072181c0f2eab9f2dd8db2eb3b9556d7cd0bd74  # frozen: 1.17.0
+    rev: f857ca370af3db7e5e181373d45c06a148fac3f8  # frozen: 1.19.1
     hooks:
       - id: yamlfix
         args:
@@ -80,7 +80,7 @@ repos:
           - .yamlfix.toml
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: 79a6b2b1392eaf49cdd32ac4f14be1a809bbd8f7  # frozen: v1.37.1
+    rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
     hooks:
       - id: yamllint
         args:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md — Dragonfly Mainframe Local Tooling
+
+The workspace root `AGENTS.md` remains authoritative. These instructions add
+repository-specific local test tooling.
+
+## PostgreSQL Tests
+
+Docker will not be installed for this repository. Run database-backed tests
+against an isolated local PostgreSQL instance using Unix-domain sockets.
+
+PostgreSQL 16 server binaries are installed under
+`/usr/lib/postgresql/16/bin`, even when they are not present on `PATH`.
+
+Keep disposable server state and sockets under `/tmp`, use a non-default port,
+and pass the socket explicitly in `DB_URL`. A representative setup is:
+
+```bash
+MAINFRAME_PG_BIN=/usr/lib/postgresql/16/bin
+MAINFRAME_PG_DATA=/tmp/vipyrsec-mainframe-pgdata
+MAINFRAME_PG_SOCKET=/tmp/vipyrsec-mainframe-pgsocket
+MAINFRAME_PG_PORT=55432
+
+mkdir -p "$MAINFRAME_PG_SOCKET"
+"$MAINFRAME_PG_BIN/initdb" -D "$MAINFRAME_PG_DATA" --auth=trust
+"$MAINFRAME_PG_BIN/pg_ctl" \
+  -D "$MAINFRAME_PG_DATA" \
+  -o "-h '' -k $MAINFRAME_PG_SOCKET -p $MAINFRAME_PG_PORT" \
+  -w start
+createuser \
+  --host="$MAINFRAME_PG_SOCKET" \
+  --port="$MAINFRAME_PG_PORT" \
+  --username="$(id -un)" \
+  --superuser \
+  postgres
+createdb \
+  --host="$MAINFRAME_PG_SOCKET" \
+  --port="$MAINFRAME_PG_PORT" \
+  --username=postgres \
+  dragonfly
+```
+
+Run tests with:
+
+```bash
+DRAGONFLY_GITHUB_TOKEN=test \
+  DB_URL="postgresql+psycopg2://postgres:postgres@/dragonfly?host=$MAINFRAME_PG_SOCKET&port=$MAINFRAME_PG_PORT" \
+  uv run --locked pytest
+```
+
+Stop the disposable server after validation:
+
+```bash
+"$MAINFRAME_PG_BIN/pg_ctl" -D "$MAINFRAME_PG_DATA" -m fast -w stop
+```
+
+## Workspace Tools
+
+Hadolint and the audited `prek` runner are installed at:
+
+* `/home/rem/github/vipyrsec/.tools/bin/hadolint`
+* `/home/rem/github/vipyrsec/.tools/bin/prek-workspace`
+
+Run the repository hook suite with:
+
+```bash
+/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files
+```

--- a/alembic/versions/f6c1e85d4a29_add_alerting_configuration.py
+++ b/alembic/versions/f6c1e85d4a29_add_alerting_configuration.py
@@ -1,0 +1,49 @@
+"""add alerting configuration
+
+Revision ID: f6c1e85d4a29
+Revises: 3f42e287fc2f
+Create Date: 2026-07-25 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "f6c1e85d4a29"
+down_revision = "3f42e287fc2f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "alerting_configuration",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("production_score_threshold", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_by", sa.String(), nullable=False),
+        sa.CheckConstraint(
+            "production_score_threshold >= 0",
+            name="alerting_configuration_nonnegative_threshold",
+        ),
+        sa.CheckConstraint("id = 1", name="alerting_configuration_singleton"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO alerting_configuration (
+                id,
+                production_score_threshold,
+                updated_at,
+                updated_by
+            )
+            VALUES (1, 8, CURRENT_TIMESTAMP, 'database-migration')
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("alerting_configuration")

--- a/src/mainframe/dependencies.py
+++ b/src/mainframe/dependencies.py
@@ -6,6 +6,7 @@ from fastapi import Depends, Request
 
 from mainframe.access_token import get_access_token
 from mainframe.json_web_token import AuthenticationData, JsonWebToken
+from mainframe.performance_monitor import PerformanceMonitor
 from mainframe.pypi import PyPIClient
 from mainframe.queue_monitor import QueueMonitor
 from mainframe.rules import Rules
@@ -28,6 +29,11 @@ def get_rules(request: Request) -> Rules:
 def get_queue_monitor(request: Request) -> QueueMonitor:
     """Return the process-local cached queue monitor."""
     return request.app.state.queue_monitor
+
+
+def get_performance_monitor(request: Request) -> PerformanceMonitor:
+    """Return the process-local cached performance monitor."""
+    return request.app.state.performance_monitor
 
 
 def validate_token(token: Annotated[str, Depends(get_access_token)]) -> AuthenticationData:

--- a/src/mainframe/endpoints/alerting.py
+++ b/src/mainframe/endpoints/alerting.py
@@ -1,0 +1,63 @@
+import datetime as dt
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from mainframe.database import get_db
+from mainframe.dependencies import validate_token
+from mainframe.json_web_token import AuthenticationData
+from mainframe.models.orm import AlertingConfiguration
+from mainframe.models.schemas import (
+    AlertingConfigurationResponse,
+    AlertingConfigurationUpdate,
+)
+
+router = APIRouter(prefix="/alerting", tags=["alerting"])
+
+
+def _get_configuration(session: Session) -> AlertingConfiguration:
+    configuration = session.scalar(select(AlertingConfiguration).where(AlertingConfiguration.id == 1))
+    if configuration is None:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Alerting configuration is unavailable.",
+        )
+    return configuration
+
+
+def _to_response(
+    configuration: AlertingConfiguration,
+) -> AlertingConfigurationResponse:
+    return AlertingConfigurationResponse(
+        production_score_threshold=configuration.production_score_threshold,
+        updated_at=configuration.updated_at,
+        updated_by=configuration.updated_by,
+    )
+
+
+@router.get("/configuration")
+def get_alerting_configuration(
+    session: Annotated[Session, Depends(get_db)],
+    _auth: Annotated[AuthenticationData, Depends(validate_token)],
+) -> AlertingConfigurationResponse:
+    """Return the durable production alerting configuration."""
+    with session.begin():
+        return _to_response(_get_configuration(session))
+
+
+@router.put("/configuration")
+def update_alerting_configuration(
+    body: AlertingConfigurationUpdate,
+    session: Annotated[Session, Depends(get_db)],
+    auth: Annotated[AuthenticationData, Depends(validate_token)],
+) -> AlertingConfigurationResponse:
+    """Replace the mutable production alerting configuration."""
+    with session.begin():
+        configuration = _get_configuration(session)
+        configuration.production_score_threshold = body.production_score_threshold
+        configuration.updated_at = dt.datetime.now(dt.UTC)
+        configuration.updated_by = auth.subject
+        session.flush()
+        return _to_response(configuration)

--- a/src/mainframe/endpoints/performance.py
+++ b/src/mainframe/endpoints/performance.py
@@ -1,0 +1,46 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from mainframe.dependencies import get_performance_monitor, validate_token
+from mainframe.models.schemas import PublicStatistics, RulePerformance
+from mainframe.performance_monitor import PerformanceMonitor
+
+router = APIRouter(tags=["performance"])
+
+
+@router.get("/rules/performance", dependencies=[Depends(validate_token)])
+def rule_performance(
+    monitor: Annotated[PerformanceMonitor, Depends(get_performance_monitor)],
+) -> RulePerformance:
+    """Return internal hit counts keyed by full rule name."""
+    snapshot = monitor.get_snapshot()
+    if snapshot is None:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Rule performance is not available yet.",
+        )
+
+    return RulePerformance(
+        hits=snapshot.rule_hits,
+        sampled_at=snapshot.sampled_at,
+    )
+
+
+@router.get("/public/statistics")
+def public_statistics(
+    monitor: Annotated[PerformanceMonitor, Depends(get_performance_monitor)],
+) -> PublicStatistics:
+    """Return package totals explicitly approved for public display."""
+    snapshot = monitor.get_snapshot()
+    if snapshot is None:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Public statistics are not available yet.",
+        )
+
+    return PublicStatistics(
+        packages_scanned=snapshot.packages_scanned,
+        packages_reported=snapshot.packages_reported,
+        sampled_at=snapshot.sampled_at,
+    )

--- a/src/mainframe/endpoints/report.py
+++ b/src/mainframe/endpoints/report.py
@@ -13,7 +13,6 @@ from mainframe.constants import mainframe_settings
 from mainframe.database import get_db
 from mainframe.dependencies import get_httpx_client, validate_token
 from mainframe.json_web_token import AuthenticationData
-from mainframe.metrics import packages_reported
 from mainframe.models.orm import Scan
 from mainframe.models.schemas import (
     Error,
@@ -199,5 +198,3 @@ def report_package(
         },
         reported_by=auth.subject,
     )
-
-    packages_reported.inc()

--- a/src/mainframe/metrics.py
+++ b/src/mainframe/metrics.py
@@ -38,9 +38,9 @@ packages_above_production_threshold = Gauge(
     "packages_above_production_threshold",
     "Database-reconciled number of successful scans at or above the production score threshold.",
 )
-packages_reported = Gauge(
-    "packages_reported",
-    "Database-reconciled number of packages reported.",
+packages_reported_snapshot = Gauge(
+    "packages_reported_snapshot",
+    "Latest database-reconciled number of packages reported.",
 )
 production_score_threshold = Gauge(
     "production_score_threshold",

--- a/src/mainframe/metrics.py
+++ b/src/mainframe/metrics.py
@@ -25,7 +25,35 @@ packages_queue_refresh_failures = Counter(
     "Number of failed database queue snapshot refreshes.",
 )
 
+rule_hits = Gauge(
+    "rule_hits",
+    "Database-reconciled number of successful scans that matched a rule.",
+    ["rule"],
+)
+packages_scanned = Gauge(
+    "packages_scanned",
+    "Database-reconciled number of successfully completed package scans.",
+)
+packages_above_production_threshold = Gauge(
+    "packages_above_production_threshold",
+    "Database-reconciled number of successful scans at or above the production score threshold.",
+)
+packages_reported = Gauge(
+    "packages_reported",
+    "Database-reconciled number of packages reported.",
+)
+production_score_threshold = Gauge(
+    "production_score_threshold",
+    "Current persisted production score threshold.",
+)
+performance_snapshot_timestamp_seconds = Gauge(
+    "performance_snapshot_timestamp_seconds",
+    "Unix timestamp of the latest successful database performance snapshot.",
+)
+performance_refresh_failures = Counter(
+    "performance_refresh_failures",
+    "Number of failed database performance snapshot refreshes.",
+)
+
 packages_success = Counter("packages_success", "Number of packages scanned successfully")
 packages_fail = Counter("packages_fail", "Number of packages that failed scanning")
-
-packages_reported = Counter("packages_reported", "Number of packages reported")

--- a/src/mainframe/models/orm.py
+++ b/src/mainframe/models/orm.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from enum import Enum
 
 from sqlalchemy import (
+    CheckConstraint,
     Column,
     DateTime,
     FetchedValue,
@@ -130,3 +131,24 @@ class Rule(Base):
     )
 
     name: Mapped[str] = mapped_column(unique=True, kw_only=True)
+
+
+class AlertingConfiguration(Base):
+    """Durable alerting configuration shared by Mainframe clients."""
+
+    __tablename__: str = "alerting_configuration"
+    __table_args__ = (
+        CheckConstraint("id = 1", name="alerting_configuration_singleton"),
+        CheckConstraint(
+            "production_score_threshold >= 0",
+            name="alerting_configuration_nonnegative_threshold",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, default=1)
+    production_score_threshold: Mapped[int] = mapped_column(default=8)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default_factory=lambda: datetime.now(UTC),
+    )
+    updated_by: Mapped[str] = mapped_column(default="system")

--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -31,6 +31,46 @@ class QueueStatus(BaseModel):
         return int(value.timestamp()) if value is not None else None
 
 
+class PerformanceStatus(BaseModel):
+    """Database-derived rule and package performance totals."""
+
+    packages_scanned: int
+    packages_above_production_threshold: int
+    packages_reported: int
+    production_score_threshold: int
+    rule_hits: dict[str, int]
+    sampled_at: datetime.datetime
+
+
+class RulePerformance(BaseModel):
+    """Internal per-rule performance totals."""
+
+    hits: dict[str, int]
+    sampled_at: datetime.datetime
+
+
+class PublicStatistics(BaseModel):
+    """Public package totals safe for unauthenticated consumers."""
+
+    packages_scanned: int
+    packages_reported: int
+    sampled_at: datetime.datetime
+
+
+class AlertingConfigurationResponse(BaseModel):
+    """Persisted production alerting configuration."""
+
+    production_score_threshold: int
+    updated_at: datetime.datetime
+    updated_by: str
+
+
+class AlertingConfigurationUpdate(BaseModel):
+    """Mutable production alerting configuration."""
+
+    production_score_threshold: int = Field(ge=0)
+
+
 class Error(BaseModel):
     """Error."""
 

--- a/src/mainframe/performance_monitor.py
+++ b/src/mainframe/performance_monitor.py
@@ -1,0 +1,98 @@
+import datetime as dt
+from threading import Lock
+
+from sqlalchemy import Engine, func, select
+from sqlalchemy.orm import Session
+
+from mainframe.metrics import (
+    packages_above_production_threshold,
+    packages_reported,
+    packages_scanned,
+    performance_snapshot_timestamp_seconds,
+    production_score_threshold,
+    rule_hits,
+)
+from mainframe.models.orm import (
+    AlertingConfiguration,
+    Rule,
+    Scan,
+    Status,
+    package_rules,
+)
+from mainframe.models.schemas import PerformanceStatus
+
+
+def read_performance_status(session: Session, *, now: dt.datetime) -> PerformanceStatus:
+    """Read durable package and per-rule performance totals."""
+    threshold = session.scalar(
+        select(AlertingConfiguration.production_score_threshold).where(AlertingConfiguration.id == 1)
+    )
+    if threshold is None:
+        msg = "Alerting configuration is missing"
+        raise RuntimeError(msg)
+
+    totals = session.execute(
+        select(
+            func.count().filter(Scan.status == Status.FINISHED),
+            func.count().filter((Scan.status == Status.FINISHED) & (Scan.score >= threshold)),
+            func.count().filter(Scan.reported_at.is_not(None)),
+        ).select_from(Scan)
+    ).one()
+    rule_rows = session.execute(
+        select(
+            Rule.name,
+            func.count(package_rules.c.scan_id).filter(Scan.status == Status.FINISHED),
+        )
+        .select_from(Rule)
+        .outerjoin(package_rules, Rule.id == package_rules.c.rule_id)
+        .outerjoin(Scan, Scan.scan_id == package_rules.c.scan_id)
+        .group_by(Rule.id, Rule.name)
+        .order_by(Rule.name)
+    )
+
+    return PerformanceStatus(
+        packages_scanned=int(totals[0]),
+        packages_above_production_threshold=int(totals[1]),
+        packages_reported=int(totals[2]),
+        production_score_threshold=threshold,
+        rule_hits={name: int(hit_count) for name, hit_count in rule_rows},
+        sampled_at=now,
+    )
+
+
+class PerformanceMonitor:
+    """Periodically publish durable performance totals to Prometheus."""
+
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+        self._snapshot: PerformanceStatus | None = None
+        self._published_rules: set[str] = set()
+        self._lock = Lock()
+
+    def refresh(self, *, now: dt.datetime | None = None) -> PerformanceStatus:
+        sampled_at = now or dt.datetime.now(dt.UTC)
+        with Session(bind=self.engine) as session, session.begin():
+            snapshot = read_performance_status(session, now=sampled_at)
+
+        packages_scanned.set(snapshot.packages_scanned)
+        packages_above_production_threshold.set(snapshot.packages_above_production_threshold)
+        packages_reported.set(snapshot.packages_reported)
+        production_score_threshold.set(snapshot.production_score_threshold)
+        performance_snapshot_timestamp_seconds.set(snapshot.sampled_at.timestamp())
+
+        current_rules = set(snapshot.rule_hits)
+        with self._lock:
+            removed_rules = self._published_rules - current_rules
+            self._published_rules = current_rules
+            self._snapshot = snapshot
+        for rule_name in removed_rules:
+            rule_hits.remove(rule_name)
+        for rule_name, hit_count in snapshot.rule_hits.items():
+            rule_hits.labels(rule=rule_name).set(hit_count)
+
+        return snapshot
+
+    def get_snapshot(self) -> PerformanceStatus | None:
+        """Return the latest database-derived performance snapshot."""
+        with self._lock:
+            return self._snapshot

--- a/src/mainframe/performance_monitor.py
+++ b/src/mainframe/performance_monitor.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from mainframe.metrics import (
     packages_above_production_threshold,
-    packages_reported,
+    packages_reported_snapshot,
     packages_scanned,
     performance_snapshot_timestamp_seconds,
     production_score_threshold,
@@ -76,7 +76,7 @@ class PerformanceMonitor:
 
         packages_scanned.set(snapshot.packages_scanned)
         packages_above_production_threshold.set(snapshot.packages_above_production_threshold)
-        packages_reported.set(snapshot.packages_reported)
+        packages_reported_snapshot.set(snapshot.packages_reported)
         production_score_threshold.set(snapshot.production_score_threshold)
         performance_snapshot_timestamp_seconds.set(snapshot.sampled_at.timestamp())
 

--- a/src/mainframe/server.py
+++ b/src/mainframe/server.py
@@ -21,8 +21,12 @@ from mainframe.constants import GIT_SHA, Sentry, mainframe_settings
 from mainframe.database import engine
 from mainframe.dependencies import validate_token
 from mainframe.endpoints import routers
-from mainframe.metrics import packages_queue_refresh_failures
+from mainframe.metrics import (
+    packages_queue_refresh_failures,
+    performance_refresh_failures,
+)
 from mainframe.models.schemas import ServerMetadata
+from mainframe.performance_monitor import PerformanceMonitor
 from mainframe.pypi import PyPIClient
 from mainframe.queue_monitor import QueueMonitor
 from mainframe.rules import Rules, fetch_rules
@@ -53,6 +57,20 @@ async def monitor_queue(monitor: QueueMonitor, refresh_seconds: int) -> None:
         except Exception:
             packages_queue_refresh_failures.inc()
             logging.getLogger(__name__).exception("Failed to refresh queue metrics")
+
+
+async def monitor_performance(
+    monitor: PerformanceMonitor,
+    refresh_seconds: int,
+) -> None:
+    """Refresh performance metrics independently of scrape traffic."""
+    while True:
+        await asyncio.sleep(refresh_seconds)
+        try:
+            await asyncio.to_thread(monitor.refresh)
+        except Exception:
+            performance_refresh_failures.inc()
+            logging.getLogger(__name__).exception("Failed to refresh performance metrics")
 
 
 sentry_sdk.init(
@@ -88,12 +106,28 @@ async def lifespan(app_: FastAPI) -> AsyncGenerator[None, None]:
     queue_monitor_task = asyncio.create_task(
         monitor_queue(queue_monitor, mainframe_settings.queue_metrics_refresh_seconds)
     )
+    performance_monitor = PerformanceMonitor(engine)
+    app_.state.performance_monitor = performance_monitor
+    try:
+        await asyncio.to_thread(performance_monitor.refresh)
+    except Exception:
+        performance_refresh_failures.inc()
+        logging.getLogger(__name__).exception("Failed to load initial performance metrics")
+    performance_monitor_task = asyncio.create_task(
+        monitor_performance(
+            performance_monitor,
+            mainframe_settings.queue_metrics_refresh_seconds,
+        )
+    )
 
     yield
 
     queue_monitor_task.cancel()
+    performance_monitor_task.cancel()
     with suppress(asyncio.CancelledError):
         await queue_monitor_task
+    with suppress(asyncio.CancelledError):
+        await performance_monitor_task
 
 
 app = FastAPI(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from mainframe.dependencies import validate_token
 from mainframe.json_web_token import AuthenticationData
-from mainframe.models.orm import Base, Scan
+from mainframe.models.orm import AlertingConfiguration, Base, Scan
 from mainframe.pypi import Distribution, PackageMetadata, PyPIClient
 from mainframe.rules import Rules
 from mainframe.server import app
@@ -67,6 +67,12 @@ def db_session(
     Base.metadata.drop_all(superuser_engine)
     Base.metadata.create_all(superuser_engine)
     with sm() as s, s.begin():
+        s.add(
+            AlertingConfiguration(
+                production_score_threshold=8,
+                updated_by="test-fixture",
+            )
+        )
         s.add_all(deepcopy(test_data))
 
     with sm() as s:

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -1,0 +1,54 @@
+import pytest
+from fastapi import HTTPException, status
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from mainframe.endpoints.alerting import (
+    get_alerting_configuration,
+    update_alerting_configuration,
+)
+from mainframe.json_web_token import AuthenticationData
+from mainframe.models.orm import AlertingConfiguration
+from mainframe.models.schemas import AlertingConfigurationUpdate
+
+
+def test_get_alerting_configuration(
+    db_session: Session,
+    auth: AuthenticationData,
+) -> None:
+    response = get_alerting_configuration(db_session, auth)
+
+    assert response.production_score_threshold == 8
+    assert response.updated_by == "test-fixture"
+
+
+def test_update_alerting_configuration(
+    db_session: Session,
+    auth: AuthenticationData,
+) -> None:
+    response = update_alerting_configuration(
+        AlertingConfigurationUpdate(production_score_threshold=12),
+        db_session,
+        auth,
+    )
+
+    assert response.production_score_threshold == 12
+    assert response.updated_by == auth.subject
+    with db_session.begin():
+        configuration = db_session.scalar(select(AlertingConfiguration))
+    assert configuration is not None
+    assert configuration.production_score_threshold == 12
+    assert configuration.updated_by == auth.subject
+
+
+def test_missing_alerting_configuration_returns_service_unavailable(
+    db_session: Session,
+    auth: AuthenticationData,
+) -> None:
+    with db_session.begin():
+        db_session.execute(delete(AlertingConfiguration))
+
+    with pytest.raises(HTTPException) as error:
+        get_alerting_configuration(db_session, auth)
+
+    assert error.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -30,16 +30,19 @@ from mainframe.json_web_token import (
 from mainframe.server import app
 
 PROTECTED_ROUTES = {
+    ("GET", "/alerting/configuration"),
     ("GET", "/package"),
     ("GET", "/queue-status"),
     ("GET", "/reported-packages"),
     ("GET", "/rules"),
+    ("GET", "/rules/performance"),
     ("POST", "/batch/package"),
     ("POST", "/jobs"),
     ("POST", "/package"),
     ("POST", "/report"),
     ("POST", "/update-rules/"),
     ("PUT", "/package"),
+    ("PUT", "/alerting/configuration"),
 }
 
 RSA_JWK = {
@@ -217,7 +220,7 @@ def test_protected_route_inventory():
     protected_routes = {
         (method.upper(), path)
         for path, path_item in openapi_paths.items()
-        if path not in {"/", "/metrics"}
+        if path not in {"/", "/metrics", "/public/statistics"}
         for method in path_item
     }
     assert protected_routes == PROTECTED_ROUTES

--- a/tests/test_performance_monitor.py
+++ b/tests/test_performance_monitor.py
@@ -1,12 +1,14 @@
 import datetime as dt
+from unittest.mock import Mock
 
 import pytest
 from fastapi import HTTPException, status
-from sqlalchemy import Engine, update
+from sqlalchemy import Engine, delete, update
 from sqlalchemy.orm import Session
 
 from mainframe.endpoints.performance import public_statistics, rule_performance
-from mainframe.models.orm import Rule, Scan, Status
+from mainframe.metrics import rule_hits
+from mainframe.models.orm import AlertingConfiguration, Rule, Scan, Status
 from mainframe.performance_monitor import PerformanceMonitor, read_performance_status
 
 
@@ -66,6 +68,16 @@ def test_read_performance_status_uses_durable_database_state(
     assert snapshot.sampled_at == now
 
 
+def test_read_performance_status_requires_alerting_configuration(
+    db_session: Session,
+) -> None:
+    with db_session.begin():
+        db_session.execute(delete(AlertingConfiguration))
+
+    with db_session.begin(), pytest.raises(RuntimeError, match="Alerting configuration is missing"):
+        read_performance_status(db_session, now=dt.datetime.now(dt.UTC))
+
+
 def test_performance_monitor_refreshes_from_database(
     db_session: Session,
     engine: Engine,
@@ -78,6 +90,25 @@ def test_performance_monitor_refreshes_from_database(
     assert snapshot.packages_scanned == 2
     assert snapshot.packages_above_production_threshold == 1
     assert snapshot.packages_reported == 1
+
+
+def test_performance_monitor_removes_stale_rule_labels(
+    db_session: Session,
+    engine: Engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    replace_performance_data(db_session)
+    monitor = PerformanceMonitor(engine)
+    monitor.refresh()
+    remove = Mock(wraps=rule_hits.remove)
+    monkeypatch.setattr(rule_hits, "remove", remove)
+    with db_session.begin():
+        db_session.execute(update(Rule).where(Rule.name == "metrics-rule").values(name="renamed-metrics-rule"))
+
+    snapshot = monitor.refresh()
+
+    remove.assert_called_once_with("metrics-rule")
+    assert snapshot.rule_hits["renamed-metrics-rule"] == 2
 
 
 def test_rule_performance_endpoint_includes_full_rule_names(

--- a/tests/test_performance_monitor.py
+++ b/tests/test_performance_monitor.py
@@ -1,0 +1,138 @@
+import datetime as dt
+
+import pytest
+from fastapi import HTTPException, status
+from sqlalchemy import Engine, update
+from sqlalchemy.orm import Session
+
+from mainframe.endpoints.performance import public_statistics, rule_performance
+from mainframe.models.orm import Rule, Scan, Status
+from mainframe.performance_monitor import PerformanceMonitor, read_performance_status
+
+
+def replace_performance_data(session: Session) -> None:
+    rule = Rule(name="metrics-rule")
+    with session.begin():
+        session.execute(
+            update(Scan).values(
+                status=Status.FAILED,
+                score=None,
+                reported_at=None,
+            )
+        )
+        session.add_all(
+            [
+                Scan(
+                    name="metrics-safe",
+                    version="1",
+                    status=Status.FINISHED,
+                    score=7,
+                    queued_by="test",
+                    rules=[rule],
+                ),
+                Scan(
+                    name="metrics-production",
+                    version="1",
+                    status=Status.FINISHED,
+                    score=8,
+                    queued_by="test",
+                    reported_at=dt.datetime(2026, 7, 25, tzinfo=dt.UTC),
+                    rules=[rule],
+                ),
+                Scan(
+                    name="metrics-failed",
+                    version="1",
+                    status=Status.FAILED,
+                    queued_by="test",
+                ),
+            ]
+        )
+
+
+def test_read_performance_status_uses_durable_database_state(
+    db_session: Session,
+) -> None:
+    now = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    replace_performance_data(db_session)
+
+    with db_session.begin():
+        snapshot = read_performance_status(db_session, now=now)
+
+    assert snapshot.packages_scanned == 2
+    assert snapshot.packages_above_production_threshold == 1
+    assert snapshot.packages_reported == 1
+    assert snapshot.production_score_threshold == 8
+    assert snapshot.rule_hits["metrics-rule"] == 2
+    assert snapshot.sampled_at == now
+
+
+def test_performance_monitor_refreshes_from_database(
+    db_session: Session,
+    engine: Engine,
+) -> None:
+    now = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    replace_performance_data(db_session)
+
+    snapshot = PerformanceMonitor(engine).refresh(now=now)
+
+    assert snapshot.packages_scanned == 2
+    assert snapshot.packages_above_production_threshold == 1
+    assert snapshot.packages_reported == 1
+
+
+def test_rule_performance_endpoint_includes_full_rule_names(
+    db_session: Session,
+    engine: Engine,
+) -> None:
+    now = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    replace_performance_data(db_session)
+    monitor = PerformanceMonitor(engine)
+    monitor.refresh(now=now)
+
+    response = rule_performance(monitor)
+
+    assert response.hits["metrics-rule"] == 2
+    assert all(hit_count == 0 for rule_name, hit_count in response.hits.items() if rule_name != "metrics-rule")
+    assert response.sampled_at == now
+
+
+def test_public_statistics_exposes_only_approved_totals(
+    db_session: Session,
+    engine: Engine,
+) -> None:
+    now = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    replace_performance_data(db_session)
+    monitor = PerformanceMonitor(engine)
+    monitor.refresh(now=now)
+
+    response = public_statistics(monitor)
+
+    assert response.model_dump() == {
+        "packages_scanned": 2,
+        "packages_reported": 1,
+        "sampled_at": now,
+    }
+    assert "rule" not in response.model_dump_json()
+    assert "threshold" not in response.model_dump_json()
+
+
+def test_rule_performance_endpoint_is_unavailable_before_initial_snapshot(
+    engine: Engine,
+) -> None:
+    monitor = PerformanceMonitor(engine)
+
+    with pytest.raises(HTTPException) as error:
+        rule_performance(monitor)
+
+    assert error.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+def test_public_statistics_is_unavailable_before_initial_snapshot(
+    engine: Engine,
+) -> None:
+    monitor = PerformanceMonitor(engine)
+
+    with pytest.raises(HTTPException) as error:
+        public_statistics(monitor)
+
+    assert error.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary

- publish database-reconciled Prometheus gauges for per-rule hits and package totals
- expose authenticated rule performance and persistent alert-threshold configuration APIs
- expose a deliberately narrow unauthenticated package statistics resource
- replace the process-local report counter with durable PostgreSQL-derived state
- document the local Unix-socket PostgreSQL and audited workspace tooling flow

## Why

Process-local counters drift after restarts and cannot reliably represent live
package state. Alert thresholds also need one durable source of truth so API
clients, including the Discord bot, make consistent production decisions.

Rule identifiers remain available to internal Prometheus and authenticated
clients. The public statistics contract exposes only package scan and report
totals, allowing a future static website integration without distributing a
Cloudflare Access credential.

## Validation

- `uv run --locked ruff format --check .`
- `uv run --locked ruff check .`
- `uv run --locked pyright`
- `uv run --locked pytest -q` (`170 passed`, PostgreSQL 16 over a Unix socket)
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
- full Alembic upgrade through the new migration on a disposable PostgreSQL database
