### PR TITLE
Add suppression REST resources

### DIFF
--- a/alembic/versions/8f4c2b1d0a77_add_suppressions.py
+++ b/alembic/versions/8f4c2b1d0a77_add_suppressions.py
@@ -1,0 +1,54 @@
+"""add suppressions
+
+Revision ID: 8f4c2b1d0a77
+Revises: f6c1e85d4a29
+Create Date: 2026-07-26 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "8f4c2b1d0a77"
+down_revision = "f6c1e85d4a29"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "suppressions",
+        sa.Column("suppression_id", sa.UUID(), nullable=False),
+        sa.Column("package_name", sa.String(), nullable=False),
+        sa.Column("package_version", sa.String(), nullable=False),
+        sa.Column("rules", postgresql.ARRAY(sa.String()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_by", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_by", sa.String(), nullable=False),
+        sa.CheckConstraint(
+            "package_name <> ''",
+            name="suppressions_package_name_nonempty",
+        ),
+        sa.CheckConstraint(
+            "package_version <> ''",
+            name="suppressions_package_version_nonempty",
+        ),
+        sa.PrimaryKeyConstraint("suppression_id"),
+    )
+    op.create_index(
+        "ix_suppressions_package_name_version",
+        "suppressions",
+        ["package_name", "package_version"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_suppressions_package_name_version",
+        table_name="suppressions",
+    )
+    op.drop_table("suppressions")

--- a/src/mainframe/endpoints/suppressions.py
+++ b/src/mainframe/endpoints/suppressions.py
@@ -1,0 +1,181 @@
+import datetime as dt
+import re
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from mainframe.database import get_db
+from mainframe.dependencies import validate_token
+from mainframe.json_web_token import AuthenticationData
+from mainframe.models.orm import Suppression
+from mainframe.models.schemas import (
+    SuppressionCreate,
+    SuppressionDeleteResponse,
+    SuppressionResponse,
+    SuppressionUpdate,
+)
+
+router = APIRouter(prefix="/packages/{package_name}", tags=["suppressions"])
+
+
+class SuppressionPath:
+    """The nested identity of one suppression resource."""
+
+    def __init__(
+        self,
+        package_name: str,
+        package_version: str,
+        suppression_id: uuid.UUID,
+    ) -> None:
+        self.package_name = package_name
+        self.package_version = package_version
+        self.suppression_id = suppression_id
+
+
+def _normalize_package_name(package_name: str) -> str:
+    """Return the normalized package name defined by PEP 503."""
+    return re.sub(r"[-_.]+", "-", package_name).lower()
+
+
+def _get_suppression(
+    session: Session,
+    *,
+    package_name: str,
+    package_version: str,
+    suppression_id: uuid.UUID,
+) -> Suppression:
+    suppression = session.scalar(
+        select(Suppression).where(
+            Suppression.suppression_id == suppression_id,
+            Suppression.package_name == _normalize_package_name(package_name),
+            Suppression.package_version == package_version,
+        )
+    )
+    if suppression is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="Suppression not found.",
+        )
+    return suppression
+
+
+@router.get("/suppressions")
+def list_package_suppressions(
+    package_name: str,
+    session: Annotated[Session, Depends(get_db)],
+    _auth: Annotated[AuthenticationData, Depends(validate_token)],
+) -> list[SuppressionResponse]:
+    """List every suppression for a package across all versions."""
+    with session.begin():
+        suppressions = session.scalars(
+            select(Suppression)
+            .where(Suppression.package_name == _normalize_package_name(package_name))
+            .order_by(Suppression.package_version, Suppression.created_at, Suppression.suppression_id)
+        ).all()
+        return [SuppressionResponse.from_db(suppression) for suppression in suppressions]
+
+
+@router.post(
+    "/versions/{package_version}/suppressions",
+    status_code=status.HTTP_201_CREATED,
+)
+def create_suppression(
+    package_name: str,
+    package_version: str,
+    body: SuppressionCreate,
+    session: Annotated[Session, Depends(get_db)],
+    auth: Annotated[AuthenticationData, Depends(validate_token)],
+) -> SuppressionResponse:
+    """Create an independently addressable suppression."""
+    suppression = Suppression(
+        package_name=_normalize_package_name(package_name),
+        package_version=package_version,
+        rules=body.rules,
+        created_by=auth.subject,
+        updated_by=auth.subject,
+    )
+    with session.begin():
+        session.add(suppression)
+        session.flush()
+        return SuppressionResponse.from_db(suppression)
+
+
+@router.get("/versions/{package_version}/suppressions/{suppression_id}")
+def get_suppression(
+    path: Annotated[SuppressionPath, Depends()],
+    session: Annotated[Session, Depends(get_db)],
+    _auth: Annotated[AuthenticationData, Depends(validate_token)],
+) -> SuppressionResponse:
+    """Get one suppression by its stable identifier."""
+    with session.begin():
+        return SuppressionResponse.from_db(
+            _get_suppression(
+                session,
+                package_name=path.package_name,
+                package_version=path.package_version,
+                suppression_id=path.suppression_id,
+            )
+        )
+
+
+@router.patch("/versions/{package_version}/suppressions/{suppression_id}")
+def update_suppression(
+    path: Annotated[SuppressionPath, Depends()],
+    body: SuppressionUpdate,
+    session: Annotated[Session, Depends(get_db)],
+    auth: Annotated[AuthenticationData, Depends(validate_token)],
+) -> SuppressionResponse:
+    """Replace the rule corpus for one suppression."""
+    with session.begin():
+        suppression = _get_suppression(
+            session,
+            package_name=path.package_name,
+            package_version=path.package_version,
+            suppression_id=path.suppression_id,
+        )
+        suppression.rules = body.rules
+        suppression.updated_at = dt.datetime.now(dt.UTC)
+        suppression.updated_by = auth.subject
+        session.flush()
+        return SuppressionResponse.from_db(suppression)
+
+
+@router.delete("/versions/{package_version}/suppressions/{suppression_id}")
+def delete_suppression(
+    path: Annotated[SuppressionPath, Depends()],
+    session: Annotated[Session, Depends(get_db)],
+    _auth: Annotated[AuthenticationData, Depends(validate_token)],
+) -> SuppressionDeleteResponse:
+    """Delete one suppression by its stable identifier."""
+    with session.begin():
+        suppression = _get_suppression(
+            session,
+            package_name=path.package_name,
+            package_version=path.package_version,
+            suppression_id=path.suppression_id,
+        )
+        session.delete(suppression)
+    return SuppressionDeleteResponse(deleted=1)
+
+
+@router.delete("/versions/{package_version}/suppressions")
+def delete_version_suppressions(
+    package_name: str,
+    package_version: str,
+    session: Annotated[Session, Depends(get_db)],
+    _auth: Annotated[AuthenticationData, Depends(validate_token)],
+) -> SuppressionDeleteResponse:
+    """Delete every suppression for one package version."""
+    with session.begin():
+        deleted_ids = session.scalars(
+            delete(Suppression)
+            .where(
+                Suppression.package_name == _normalize_package_name(package_name),
+                Suppression.package_version == package_version,
+            )
+            .returning(Suppression.suppression_id)
+        ).all()
+    return SuppressionDeleteResponse(deleted=len(deleted_ids))

--- a/src/mainframe/models/orm.py
+++ b/src/mainframe/models/orm.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from enum import Enum
 
 from sqlalchemy import (
+    ARRAY,
     CheckConstraint,
     Column,
     DateTime,
@@ -12,6 +13,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     PrimaryKeyConstraint,
+    String,
     Table,
     UniqueConstraint,
     or_,
@@ -152,3 +154,35 @@ class AlertingConfiguration(Base):
         default_factory=lambda: datetime.now(UTC),
     )
     updated_by: Mapped[str] = mapped_column(default="system")
+
+
+class Suppression(Base):
+    """A durable package-version alert suppression."""
+
+    __tablename__: str = "suppressions"
+    __table_args__ = (
+        CheckConstraint("package_name <> ''", name="suppressions_package_name_nonempty"),
+        CheckConstraint("package_version <> ''", name="suppressions_package_version_nonempty"),
+        Index("ix_suppressions_package_name_version", "package_name", "package_version"),
+    )
+
+    suppression_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default_factory=uuid.uuid4,
+        init=False,
+    )
+    package_name: Mapped[str] = mapped_column(default=None)
+    package_version: Mapped[str] = mapped_column(default=None)
+    created_by: Mapped[str] = mapped_column(default=None)
+    updated_by: Mapped[str] = mapped_column(default=None)
+    rules: Mapped[list[str] | None] = mapped_column(ARRAY(String()), default=None)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default_factory=lambda: datetime.now(UTC),
+        init=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default_factory=lambda: datetime.now(UTC),
+    )

--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -1,10 +1,14 @@
 import datetime
+import uuid
 from enum import Enum
-from typing import Any, Self
+from typing import Annotated, Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
-from .orm import Scan
+from .orm import Scan, Suppression
+
+RuleName = Annotated[str, Field(min_length=1)]
+_DUPLICATE_RULES_ERROR = "rules must not contain duplicates"
 
 
 class ServerMetadata(BaseModel):
@@ -69,6 +73,61 @@ class AlertingConfigurationUpdate(BaseModel):
     """Mutable production alerting configuration."""
 
     production_score_threshold: int = Field(ge=0)
+
+
+class SuppressionRules(BaseModel):
+    """Rule corpus for a suppression; null means every rule."""
+
+    rules: list[RuleName] | None
+
+    @field_validator("rules")
+    @classmethod
+    def rules_must_be_unique(cls, rules: list[str] | None) -> list[str] | None:
+        if rules is not None and len(rules) != len(set(rules)):
+            raise ValueError(_DUPLICATE_RULES_ERROR)
+        return rules
+
+
+class SuppressionCreate(SuppressionRules):
+    """A new suppression. Omitting rules suppresses every rule."""
+
+    rules: list[RuleName] | None = None
+
+
+class SuppressionUpdate(SuppressionRules):
+    """Replacement rule corpus for an existing suppression."""
+
+
+class SuppressionResponse(BaseModel):
+    """A durable package-version suppression."""
+
+    suppression_id: uuid.UUID
+    package_name: str
+    package_version: str
+    rules: list[str] | None
+    created_at: datetime.datetime
+    created_by: str
+    updated_at: datetime.datetime
+    updated_by: str
+
+    @classmethod
+    def from_db(cls, suppression: Suppression) -> Self:
+        return cls(
+            suppression_id=suppression.suppression_id,
+            package_name=suppression.package_name,
+            package_version=suppression.package_version,
+            rules=suppression.rules,
+            created_at=suppression.created_at,
+            created_by=suppression.created_by,
+            updated_at=suppression.updated_at,
+            updated_by=suppression.updated_by,
+        )
+
+
+class SuppressionDeleteResponse(BaseModel):
+    """Number of suppressions deleted by an operation."""
+
+    deleted: int
 
 
 class Error(BaseModel):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -32,6 +32,8 @@ from mainframe.server import app
 PROTECTED_ROUTES = {
     ("GET", "/alerting/configuration"),
     ("GET", "/package"),
+    ("GET", "/packages/{package_name}/suppressions"),
+    ("GET", "/packages/{package_name}/versions/{package_version}/suppressions/{suppression_id}"),
     ("GET", "/queue-status"),
     ("GET", "/reported-packages"),
     ("GET", "/rules"),
@@ -39,10 +41,14 @@ PROTECTED_ROUTES = {
     ("POST", "/batch/package"),
     ("POST", "/jobs"),
     ("POST", "/package"),
+    ("POST", "/packages/{package_name}/versions/{package_version}/suppressions"),
     ("POST", "/report"),
     ("POST", "/update-rules/"),
     ("PUT", "/package"),
     ("PUT", "/alerting/configuration"),
+    ("PATCH", "/packages/{package_name}/versions/{package_version}/suppressions/{suppression_id}"),
+    ("DELETE", "/packages/{package_name}/versions/{package_version}/suppressions"),
+    ("DELETE", "/packages/{package_name}/versions/{package_version}/suppressions/{suppression_id}"),
 }
 
 RSA_JWK = {

--- a/tests/test_suppressions.py
+++ b/tests/test_suppressions.py
@@ -1,0 +1,171 @@
+import asyncio
+import uuid
+from collections.abc import Generator
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from pydantic import ValidationError
+from sqlalchemy.orm import Session
+
+from mainframe.database import get_db
+from mainframe.endpoints.suppressions import (
+    SuppressionPath,
+    create_suppression,
+    delete_suppression,
+    delete_version_suppressions,
+    get_suppression,
+    list_package_suppressions,
+    update_suppression,
+)
+from mainframe.json_web_token import AuthenticationData
+from mainframe.models.schemas import SuppressionCreate, SuppressionUpdate
+
+
+def test_suppression_lifecycle_and_package_enumeration(
+    db_session: Session,
+    auth: AuthenticationData,
+) -> None:
+    all_rules = create_suppression(
+        "Example_Package",
+        "1.0.0",
+        SuppressionCreate(),
+        db_session,
+        auth,
+    )
+    one_rule = create_suppression(
+        "example-package",
+        "2.0.0",
+        SuppressionCreate(rules=["false_positive_rule"]),
+        db_session,
+        auth,
+    )
+
+    assert all_rules.package_name == "example-package"
+    assert all_rules.rules is None
+    assert all_rules.created_by == auth.subject
+    assert one_rule.suppression_id != all_rules.suppression_id
+
+    suppressions = list_package_suppressions("EXAMPLE.package", db_session, auth)
+    assert [suppression.suppression_id for suppression in suppressions] == [
+        all_rules.suppression_id,
+        one_rule.suppression_id,
+    ]
+
+    fetched = get_suppression(
+        SuppressionPath("example-package", "2.0.0", one_rule.suppression_id),
+        db_session,
+        auth,
+    )
+    assert fetched == one_rule
+
+    updated = update_suppression(
+        SuppressionPath("example-package", "2.0.0", one_rule.suppression_id),
+        SuppressionUpdate(rules=["replacement_rule"]),
+        db_session,
+        auth,
+    )
+    assert updated.rules == ["replacement_rule"]
+    assert updated.updated_by == auth.subject
+    assert updated.updated_at >= one_rule.updated_at
+
+    deleted = delete_suppression(
+        SuppressionPath("example-package", "2.0.0", one_rule.suppression_id),
+        db_session,
+        auth,
+    )
+    assert deleted.deleted == 1
+    remaining = list_package_suppressions("example-package", db_session, auth)
+    assert [suppression.suppression_id for suppression in remaining] == [all_rules.suppression_id]
+
+
+def test_delete_all_suppressions_only_deletes_requested_version(
+    db_session: Session,
+    auth: AuthenticationData,
+) -> None:
+    first = create_suppression("example", "1.0.0", SuppressionCreate(rules=["one"]), db_session, auth)
+    create_suppression("example", "1.0.0", SuppressionCreate(rules=["two"]), db_session, auth)
+    retained = create_suppression("example", "2.0.0", SuppressionCreate(), db_session, auth)
+
+    response = delete_version_suppressions("example", "1.0.0", db_session, auth)
+
+    assert response.deleted == 2
+    assert [suppression.suppression_id for suppression in list_package_suppressions("example", db_session, auth)] == [
+        retained.suppression_id
+    ]
+    with pytest.raises(HTTPException) as error:
+        get_suppression(SuppressionPath("example", "1.0.0", first.suppression_id), db_session, auth)
+    assert error.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_suppression_identity_is_scoped_to_package_and_version(
+    db_session: Session,
+    auth: AuthenticationData,
+) -> None:
+    suppression = create_suppression("example", "1.0.0", SuppressionCreate(), db_session, auth)
+
+    with pytest.raises(HTTPException) as error:
+        get_suppression(SuppressionPath("other", "1.0.0", suppression.suppression_id), db_session, auth)
+    assert error.value.status_code == status.HTTP_404_NOT_FOUND
+
+    with pytest.raises(HTTPException) as error:
+        get_suppression(SuppressionPath("example", "2.0.0", suppression.suppression_id), db_session, auth)
+    assert error.value.status_code == status.HTTP_404_NOT_FOUND
+
+    with pytest.raises(HTTPException) as error:
+        get_suppression(SuppressionPath("example", "1.0.0", uuid.uuid4()), db_session, auth)
+    assert error.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_rule_corpus_distinguishes_all_rules_from_no_rules() -> None:
+    assert SuppressionCreate().rules is None
+    assert SuppressionCreate(rules=[]).rules == []
+
+    with pytest.raises(ValidationError, match="rules must not contain duplicates"):
+        SuppressionCreate(rules=["duplicate", "duplicate"])
+
+    with pytest.raises(ValidationError):
+        SuppressionCreate(rules=[""])
+
+
+def test_suppression_http_resource_routes(
+    db_session: Session,
+    app_without_auth: FastAPI,
+) -> None:
+    def get_test_db() -> Generator[Session, None, None]:
+        yield db_session
+
+    app_without_auth.dependency_overrides[get_db] = get_test_db
+
+    async def exercise_routes() -> None:
+        transport = httpx.ASGITransport(app=app_without_auth)
+        collection = "/packages/Example_Package/versions/1.0%2Blocal/suppressions"
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            created = await client.post(collection, json={"rules": ["false_positive_rule"]})
+            assert created.status_code == status.HTTP_201_CREATED
+            suppression_id = created.json()["suppression_id"]
+
+            listed = await client.get("/packages/example-package/suppressions")
+            assert listed.status_code == status.HTTP_200_OK
+            assert [suppression["suppression_id"] for suppression in listed.json()] == [suppression_id]
+
+            item = f"{collection}/{suppression_id}"
+            fetched = await client.get(item)
+            assert fetched.status_code == status.HTTP_200_OK
+            assert fetched.json()["rules"] == ["false_positive_rule"]
+
+            invalid_update = await client.patch(item, json={})
+            assert invalid_update.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+            updated = await client.patch(item, json={"rules": None})
+            assert updated.status_code == status.HTTP_200_OK
+            assert updated.json()["rules"] is None
+
+            deleted = await client.delete(collection)
+            assert deleted.status_code == status.HTTP_200_OK
+            assert deleted.json() == {"deleted": 1}
+
+    try:
+        asyncio.run(exercise_routes())
+    finally:
+        app_without_auth.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
## Summary

- add durable, UUID-addressed package-version suppressions with audit metadata
- expose nested REST resources to list, create, view, update, delete, and bulk-delete suppressions
- distinguish `rules: null` (all rules) from an explicit rule corpus, while retaining historical rule names independently of the active YARA corpus
- normalize package names according to PEP 503 and index package/version lookups

## Why

False-positive tuning needs to survive rule removal and reintroduction. Independent suppression resources allow multiple historical decisions to coexist for the same package/version while remaining individually enumerable and editable.

## Impact

Mainframe becomes the durable source of truth for suppressions. The companion Bot change in vipyrsec/bot#326 consumes these resources for alert filtering and operator controls. Mainframe must deploy before Bot.

## Validation

- 184 pytest tests
- Alembic upgrade/downgrade/upgrade cycle against PostgreSQL 16
- Ruff, Pyright, and full `ty` checks
- complete audited `prek` hook suite
- pedantic offline `zizmor` with no findings
