### PR TITLE
Reduce performance monitor database load

### DIFF
--- a/src/mainframe/constants.py
+++ b/src/mainframe/constants.py
@@ -34,6 +34,7 @@ class Mainframe(EnvConfig):
     job_timeout: int = 60 * 2
     max_job_attempts: PositiveInt = 3
     queue_metrics_refresh_seconds: PositiveInt = 60
+    performance_metrics_refresh_seconds: PositiveInt = 15 * 60
 
     log_config_file: str = "logging/development.toml"
 

--- a/src/mainframe/performance_monitor.py
+++ b/src/mainframe/performance_monitor.py
@@ -23,7 +23,12 @@ from mainframe.models.orm import (
 from mainframe.models.schemas import PerformanceStatus
 
 
-def read_performance_status(session: Session, *, now: dt.datetime) -> PerformanceStatus:
+def read_performance_status(
+    session: Session,
+    *,
+    now: dt.datetime,
+    cached_rule_hits: dict[str, int] | None = None,
+) -> PerformanceStatus:
     """Read durable package and per-rule performance totals."""
     threshold = session.scalar(
         select(AlertingConfiguration.production_score_threshold).where(AlertingConfiguration.id == 1)
@@ -41,17 +46,21 @@ def read_performance_status(session: Session, *, now: dt.datetime) -> Performanc
             func.count().filter(Scan.reported_at.is_not(None)),
         ).select_from(Scan)
     ).one()
-    rule_rows = session.execute(
-        select(
-            Rule.name,
-            func.count(package_rules.c.scan_id).filter(Scan.status == Status.FINISHED),
+    if cached_rule_hits is None:
+        rule_rows = session.execute(
+            select(
+                Rule.name,
+                func.count(package_rules.c.scan_id).filter(Scan.status == Status.FINISHED),
+            )
+            .select_from(Rule)
+            .outerjoin(package_rules, Rule.id == package_rules.c.rule_id)
+            .outerjoin(Scan, Scan.scan_id == package_rules.c.scan_id)
+            .group_by(Rule.id, Rule.name)
+            .order_by(Rule.name)
         )
-        .select_from(Rule)
-        .outerjoin(package_rules, Rule.id == package_rules.c.rule_id)
-        .outerjoin(Scan, Scan.scan_id == package_rules.c.scan_id)
-        .group_by(Rule.id, Rule.name)
-        .order_by(Rule.name)
-    )
+        rule_hits_snapshot = {name: int(hit_count) for name, hit_count in rule_rows}
+    else:
+        rule_hits_snapshot = cached_rule_hits
 
     return PerformanceStatus(
         packages_scanned=int(totals[0]),
@@ -60,7 +69,7 @@ def read_performance_status(session: Session, *, now: dt.datetime) -> Performanc
         packages_above_production_threshold=int(totals[3]),
         packages_reported=int(totals[4]),
         production_score_threshold=threshold,
-        rule_hits={name: int(hit_count) for name, hit_count in rule_rows},
+        rule_hits=rule_hits_snapshot,
         sampled_at=now,
     )
 
@@ -74,10 +83,22 @@ class PerformanceMonitor:
         self._published_rules: set[str] = set()
         self._lock = Lock()
 
-    def refresh(self, *, now: dt.datetime | None = None) -> PerformanceStatus:
+    def refresh(
+        self,
+        *,
+        now: dt.datetime | None = None,
+        refresh_rule_hits: bool = True,
+    ) -> PerformanceStatus:
         sampled_at = now or dt.datetime.now(dt.UTC)
+        cached_rule_hits = None
+        if not refresh_rule_hits and self._snapshot is not None:
+            cached_rule_hits = self._snapshot.rule_hits
         with Session(bind=self.engine) as session, session.begin():
-            snapshot = read_performance_status(session, now=sampled_at)
+            snapshot = read_performance_status(
+                session,
+                now=sampled_at,
+                cached_rule_hits=cached_rule_hits,
+            )
 
         packages_scanned.set(snapshot.packages_scanned)
         packages_scan_outcomes.labels(outcome="finished").set(snapshot.packages_scanned)

--- a/src/mainframe/server.py
+++ b/src/mainframe/server.py
@@ -67,7 +67,7 @@ async def monitor_performance(
     while True:
         await asyncio.sleep(refresh_seconds)
         try:
-            await asyncio.to_thread(monitor.refresh)
+            await asyncio.to_thread(monitor.refresh, refresh_rule_hits=False)
         except Exception:
             performance_refresh_failures.inc()
             logging.getLogger(__name__).exception("Failed to refresh performance metrics")
@@ -120,7 +120,7 @@ async def lifespan(app_: FastAPI) -> AsyncGenerator[None, None]:
     performance_monitor_task = asyncio.create_task(
         monitor_performance(
             performance_monitor,
-            mainframe_settings.queue_metrics_refresh_seconds,
+            mainframe_settings.performance_metrics_refresh_seconds,
         )
     )
 

--- a/tests/test_performance_monitor.py
+++ b/tests/test_performance_monitor.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from fastapi import HTTPException, status
-from sqlalchemy import Engine, delete, update
+from sqlalchemy import Engine, delete, event, update
 from sqlalchemy.orm import Session
 
 from mainframe.endpoints.performance import public_statistics, rule_performance
@@ -75,6 +75,35 @@ def test_read_performance_status_uses_durable_database_state(
     assert snapshot.production_score_threshold == 8
     assert snapshot.rule_hits["metrics-rule"] == 2
     assert snapshot.sampled_at == now
+
+
+def test_background_refresh_reuses_rule_hit_snapshot(
+    db_session: Session,
+    engine: Engine,
+) -> None:
+    replace_performance_data(db_session)
+    monitor = PerformanceMonitor(engine)
+    initial_snapshot = monitor.refresh()
+    statements: list[str] = []
+
+    def capture_statement(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: object,
+    ) -> None:
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", capture_statement)
+    try:
+        snapshot = monitor.refresh(refresh_rule_hits=False)
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_statement)
+
+    assert all("package_rules" not in statement for statement in statements)
+    assert snapshot.rule_hits == initial_snapshot.rule_hits
 
 
 def test_read_performance_status_requires_alerting_configuration(


### PR DESCRIPTION
## Summary

- decouple historical performance snapshots from the 60-second queue monitor
- refresh historical totals every 15 minutes
- preserve exact rule-hit totals from startup instead of repeating the full-history join
- keep real-time package outcome counters and queue metrics unchanged

## Incident evidence

The recurring rule-hit aggregation averaged 29.1 seconds in production and the
scan totals query averaged 13.0 seconds. Both ran after every 60-second sleep
against a single-vCPU PostgreSQL cluster. The rule aggregation alone had
accumulated roughly 83.9 million milliseconds of execution time.

## Validation

- `uv run --locked ruff format --check .`
- `uv run --locked ruff check .`
- `uv run --locked pyright`
- `ty check src tests`
- `uv run --locked pytest` (196 passed)
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
- `zizmor --pedantic .github/workflows`

## Rollout

Deploy staging first and verify database activity, snapshot freshness, package
processing, and queue metrics before promoting the identical commit to
production.
