### PR TITLE
Validate OpenGrep staging API origin

### DIFF
--- a/src/mainframe/constants.py
+++ b/src/mainframe/constants.py
@@ -38,6 +38,7 @@ class Mainframe(EnvConfig):
     queue_metrics_refresh_seconds: PositiveInt = 60
     performance_metrics_refresh_seconds: PositiveInt = 15 * 60
     opengrep_shadow_enabled: bool = False
+    opengrep_shadow_api_origin: str = ""
     opengrep_publication_timeout: PositiveInt = 5 * 60
 
     log_config_file: str = "logging/development.toml"
@@ -72,9 +73,9 @@ cf_access_settings = CFAccess.model_validate({})
 
 
 def validate_opengrep_shadow_environment() -> None:
-    """Bind the shadow feature to staging's environment-specific audience."""
+    """Bind the shadow feature to the configured staging API origin."""
     if not mainframe_settings.opengrep_shadow_enabled:
         return
-    if cf_access_settings.audience.rstrip("/") != STAGING_API_ORIGIN:
-        msg = "OpenGrep shadow requires the staging Cloudflare Access audience"
+    if mainframe_settings.opengrep_shadow_api_origin.rstrip("/") != STAGING_API_ORIGIN:
+        msg = "OpenGrep shadow requires the staging API origin"
         raise RuntimeError(msg)

--- a/tests/test_opengrep.py
+++ b/tests/test_opengrep.py
@@ -80,7 +80,7 @@ def test_disabled_shadow_api_is_hidden(monkeypatch: pytest.MonkeyPatch) -> None:
     assert error.value.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_shadow_environment_requires_staging_access_audience(
+def test_shadow_environment_requires_staging_api_origin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("mainframe.constants.mainframe_settings.opengrep_shadow_enabled", False)
@@ -88,15 +88,15 @@ def test_shadow_environment_requires_staging_access_audience(
 
     monkeypatch.setattr("mainframe.constants.mainframe_settings.opengrep_shadow_enabled", True)
     monkeypatch.setattr(
-        "mainframe.constants.cf_access_settings.audience",
+        "mainframe.constants.mainframe_settings.opengrep_shadow_api_origin",
         "https://dragonfly.vipyrsec.com",
     )
 
-    with pytest.raises(RuntimeError, match="staging Cloudflare Access audience"):
+    with pytest.raises(RuntimeError, match="staging API origin"):
         validate_opengrep_shadow_environment()
 
     monkeypatch.setattr(
-        "mainframe.constants.cf_access_settings.audience",
+        "mainframe.constants.mainframe_settings.opengrep_shadow_api_origin",
         "https://dragonfly-staging.vipyrsec.com",
     )
     validate_opengrep_shadow_environment()


### PR DESCRIPTION
## Summary

- validate OpenGrep shadow mode against an explicitly configured staging API origin
- keep `CF_ACCESS_AUDIENCE` fully environment-provided
- avoid embedding the Cloudflare Access audience tag in application source

## Root cause

The original startup guard compared the Cloudflare Access audience tag to the staging URL. Those are different identifiers, so a correctly configured staging deployment could never satisfy the guard.

## Impact

Shadow mode remains staging-only through `ENVIRONMENT=staging` and now additionally requires `OPENGREP_SHADOW_API_ORIGIN=https://dragonfly-staging.vipyrsec.com`. Existing JWT audience validation is unchanged.

## Validation

- 230 tests passed against the repository-prescribed isolated PostgreSQL 16 instance
- `uv run --locked ruff check src/mainframe/constants.py tests/test_opengrep.py`
- `uv run --locked ty check`
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
- confirmed the staging Access audience hash is absent from `src` and `tests`
