### PR TITLE
Gate OpenGrep shadow work on alerts

### DIFF
--- a/alembic/versions/71e3c2a9f804_gate_opengrep_on_alerts.py
+++ b/alembic/versions/71e3c2a9f804_gate_opengrep_on_alerts.py
@@ -1,0 +1,43 @@
+"""gate OpenGrep shadow work on alerts
+
+Revision ID: 71e3c2a9f804
+Revises: 5a2f3be77d31
+Create Date: 2026-07-31 02:10:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "71e3c2a9f804"
+down_revision = "5a2f3be77d31"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "opengrep_scans",
+        sa.Column("alerted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.drop_index("ix_opengrep_scans_status", table_name="opengrep_scans")
+    op.create_index(
+        "ix_opengrep_scans_status",
+        "opengrep_scans",
+        ["status"],
+        unique=False,
+        postgresql_where=sa.text("alerted_at IS NOT NULL AND (status = 'QUEUED' OR status = 'PENDING')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_opengrep_scans_status", table_name="opengrep_scans")
+    op.create_index(
+        "ix_opengrep_scans_status",
+        "opengrep_scans",
+        ["status"],
+        unique=False,
+        postgresql_where=sa.text("status = 'QUEUED' OR status = 'PENDING'"),
+    )
+    op.drop_column("opengrep_scans", "alerted_at")

--- a/src/mainframe/endpoints/opengrep.py
+++ b/src/mainframe/endpoints/opengrep.py
@@ -22,6 +22,8 @@ from mainframe.models.schemas import (
     OpenGrepResult,
     OpenGrepScanResult,
     OpenGrepScanResultFail,
+    PackageSpecifier,
+    QueuePackageResponse,
 )
 from mainframe.rules import Rules
 
@@ -63,6 +65,7 @@ def dead_letter_expired_shadow_scans(
     session.execute(
         update(OpenGrepScan)
         .where(
+            OpenGrepScan.alerted_at.is_not(None),
             OpenGrepScan.status == Status.PENDING,
             OpenGrepScan.pending_at < retry_before,
             OpenGrepScan.attempt_count >= mainframe_settings.max_job_attempts,
@@ -74,6 +77,44 @@ def dead_letter_expired_shadow_scans(
             finished_at=now,
         )
     )
+
+
+@router.post("/alerts")
+def queue_opengrep_alert(
+    package: PackageSpecifier,
+    session: Database,
+    auth: Authenticated,
+) -> QueuePackageResponse:
+    """Create idempotent shadow work only for a package selected for alerting."""
+    with session.begin():
+        scan = session.scalar(
+            select(Scan).where(Scan.name == package.name, Scan.version == package.version).with_for_update()
+        )
+        if scan is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        if scan.status != Status.FINISHED:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "OpenGrep shadow work requires a finished canonical scan.",
+            )
+
+        shadow = session.get(OpenGrepScan, scan.scan_id)
+        if shadow is None:
+            now = dt.datetime.now(dt.UTC)
+            shadow = OpenGrepScan(
+                scan_id=scan.scan_id,
+                alerted_at=now,
+                queued_at=now,
+                queued_by=auth.subject,
+            )
+            session.add(shadow)
+        elif shadow.alerted_at is None:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "This package has an inert pre-alert-gate shadow record.",
+            )
+
+        return QueuePackageResponse(id=str(scan.scan_id))
 
 
 @router.post("/jobs")
@@ -89,6 +130,8 @@ WITH candidates AS (
     SELECT opengrep_scans.scan_id
     FROM opengrep_scans
     WHERE
+        opengrep_scans.alerted_at IS NOT NULL
+        AND
         opengrep_scans.attempt_count < :max_job_attempts
         AND (
             opengrep_scans.status = 'QUEUED'
@@ -216,6 +259,7 @@ def get_unpublished_opengrep_results(
             select(OpenGrepScan, Scan)
             .join(Scan, Scan.scan_id == OpenGrepScan.scan_id)
             .where(
+                OpenGrepScan.alerted_at.is_not(None),
                 OpenGrepScan.status.in_((Status.FINISHED, Status.FAILED)),
                 OpenGrepScan.published_at.is_(None),
                 or_(

--- a/src/mainframe/endpoints/opengrep.py
+++ b/src/mainframe/endpoints/opengrep.py
@@ -109,10 +109,28 @@ def queue_opengrep_alert(
             )
             session.add(shadow)
         elif shadow.alerted_at is None:
-            raise HTTPException(
-                status.HTTP_409_CONFLICT,
-                "This package has an inert pre-alert-gate shadow record.",
-            )
+            now = dt.datetime.now(dt.UTC)
+            shadow.status = Status.QUEUED
+            shadow.alerted_at = now
+            shadow.queued_at = now
+            shadow.queued_by = auth.subject
+            shadow.pending_at = None
+            shadow.pending_by = None
+            shadow.attempt_count = 0
+            shadow.assignment_id = None
+            shadow.dead_lettered_at = None
+            shadow.finished_at = None
+            shadow.finished_by = None
+            shadow.fail_reason = None
+            shadow.commit_hash = None
+            shadow.duration_ms = None
+            shadow.findings = []
+            shadow.publication_id = None
+            shadow.publication_claimed_at = None
+            shadow.discord_message_id = None
+            shadow.discord_thread_id = None
+            shadow.published_chunks = 0
+            shadow.published_at = None
 
         return QueuePackageResponse(id=str(scan.scan_id))
 

--- a/src/mainframe/endpoints/package.py
+++ b/src/mainframe/endpoints/package.py
@@ -11,12 +11,11 @@ from sqlalchemy import select, tuple_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
-from mainframe.constants import mainframe_settings
 from mainframe.database import get_db
 from mainframe.dependencies import get_pypi_client, validate_token
 from mainframe.json_web_token import AuthenticationData
 from mainframe.metrics import packages_fail, packages_ingested, packages_success
-from mainframe.models.orm import DownloadURL, OpenGrepScan, Rule, Scan, Status
+from mainframe.models.orm import DownloadURL, Rule, Scan, Status
 from mainframe.models.schemas import (
     Error,
     Package,
@@ -32,20 +31,6 @@ logger: structlog.stdlib.BoundLogger = structlog.get_logger()
 
 DEFAULT_REPORTED_PACKAGE_PAGE = 1
 DEFAULT_REPORTED_PACKAGE_SIZE = 50
-
-
-def add_opengrep_shadow(session: Session, scan: Scan) -> None:
-    """Create independent shadow work only when staging enables OpenGrep."""
-    if not mainframe_settings.opengrep_shadow_enabled:
-        return
-    session.flush([scan])
-    session.add(
-        OpenGrepScan(
-            scan_id=scan.scan_id,
-            queued_at=scan.queued_at or dt.datetime.now(dt.UTC),
-            queued_by=scan.queued_by,
-        )
-    )
 
 
 @router.put(
@@ -328,7 +313,6 @@ def batch_queue_package(
             )
 
             session.add(scan)
-            add_opengrep_shadow(session, scan)
 
             packages_ingested.inc()
 
@@ -375,7 +359,6 @@ def queue_package(
     try:
         with session, session.begin():
             session.add(new_package)
-            add_opengrep_shadow(session, new_package)
     except IntegrityError as err:
         msg = f"Package {name}@{version} is already queued for scanning"
         log.warning(msg, tag="already_queued")

--- a/src/mainframe/models/orm.py
+++ b/src/mainframe/models/orm.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     String,
     Table,
     UniqueConstraint,
+    and_,
     or_,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -131,6 +132,7 @@ class OpenGrepScan(Base):
         kw_only=True,
     )
     status: Mapped[Status] = mapped_column(default=Status.QUEUED)
+    alerted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
     queued_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default_factory=lambda: datetime.now(UTC),
@@ -158,9 +160,12 @@ class OpenGrepScan(Base):
 Index(
     "ix_opengrep_scans_status",
     OpenGrepScan.status,
-    postgresql_where=or_(
-        OpenGrepScan.status == Status.QUEUED,
-        OpenGrepScan.status == Status.PENDING,
+    postgresql_where=and_(
+        OpenGrepScan.alerted_at.is_not(None),
+        or_(
+            OpenGrepScan.status == Status.QUEUED,
+            OpenGrepScan.status == Status.PENDING,
+        ),
     ),
 )
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -42,6 +42,7 @@ PROTECTED_ROUTES = {
     ("GET", "/rules/performance"),
     ("POST", "/batch/package"),
     ("POST", "/jobs"),
+    ("POST", "/opengrep/alerts"),
     ("POST", "/opengrep/jobs"),
     ("POST", "/opengrep/results/{scan_id}/publication"),
     ("POST", "/opengrep/results/{scan_id}/heartbeat"),

--- a/tests/test_opengrep.py
+++ b/tests/test_opengrep.py
@@ -163,6 +163,34 @@ def test_alert_creates_idempotent_shadow_work(
         assert shadow.queued_by == auth.subject
 
 
+def test_alert_requires_an_existing_finished_scan(
+    db_session: Session,
+    auth: AuthenticationData,
+) -> None:
+    missing = PackageSpecifier(name="missing-alert-package", version="1.0.0")
+    with pytest.raises(HTTPException) as missing_error:
+        queue_opengrep_alert(missing, db_session, auth)
+    assert missing_error.value.status_code == status.HTTP_404_NOT_FOUND
+
+    unfinished = Scan(
+        name="unfinished-alert-package",
+        version="1.0.0",
+        status=Status.QUEUED,
+        queued_by="scanner",
+        download_urls=[DownloadURL(url="https://files.example/unfinished-alert-package.whl")],
+    )
+    with db_session.begin():
+        db_session.add(unfinished)
+
+    with pytest.raises(HTTPException, match="requires a finished canonical scan") as unfinished_error:
+        queue_opengrep_alert(
+            PackageSpecifier(name=unfinished.name, version=unfinished.version),
+            db_session,
+            auth,
+        )
+    assert unfinished_error.value.status_code == status.HTTP_409_CONFLICT
+
+
 def test_pre_gate_shadow_work_stays_inert(
     db_session: Session,
     auth: AuthenticationData,

--- a/tests/test_opengrep.py
+++ b/tests/test_opengrep.py
@@ -191,7 +191,7 @@ def test_alert_requires_an_existing_finished_scan(
     assert unfinished_error.value.status_code == status.HTTP_409_CONFLICT
 
 
-def test_pre_gate_shadow_work_stays_inert(
+def test_alert_reinitializes_only_its_pre_gate_shadow_row(
     db_session: Session,
     auth: AuthenticationData,
     rules_state: Rules,
@@ -209,18 +209,53 @@ def test_pre_gate_shadow_work_stays_inert(
         db_session.add(
             OpenGrepScan(
                 scan_id=scan.scan_id,
+                status=Status.FINISHED,
                 queued_at=dt.datetime.now(dt.UTC),
                 queued_by="legacy-ingestion",
+                attempt_count=2,
+                assignment_id=uuid.uuid4(),
+                finished_at=dt.datetime.now(dt.UTC),
+                finished_by="legacy-worker",
+                commit_hash="legacy-rules",
+                duration_ms=123,
+                findings=[{"rule_id": "legacy-finding"}],
+                publication_id=uuid.uuid4(),
+                publication_claimed_at=dt.datetime.now(dt.UTC),
+                discord_message_id=100,
+                discord_thread_id=200,
+                published_chunks=3,
+                published_at=dt.datetime.now(dt.UTC),
             )
         )
 
-    with pytest.raises(HTTPException, match="inert pre-alert-gate"):
-        queue_opengrep_alert(
-            PackageSpecifier(name=scan.name, version=scan.version),
-            db_session,
-            auth,
-        )
-    assert get_opengrep_jobs(db_session, auth, rules_state) == []
+    queue_opengrep_alert(
+        PackageSpecifier(name=scan.name, version=scan.version),
+        db_session,
+        auth,
+    )
+    jobs = get_opengrep_jobs(db_session, auth, rules_state)
+
+    assert len(jobs) == 1
+    assert jobs[0].name == scan.name
+    with db_session.begin():
+        shadow = db_session.get(OpenGrepScan, scan.scan_id)
+        assert shadow is not None
+        assert shadow.alerted_at is not None
+        assert shadow.status == Status.PENDING
+        assert shadow.queued_by == auth.subject
+        assert shadow.attempt_count == 1
+        assert shadow.assignment_id == jobs[0].assignment_id
+        assert shadow.finished_at is None
+        assert shadow.finished_by is None
+        assert shadow.commit_hash is None
+        assert shadow.duration_ms is None
+        assert shadow.findings == []
+        assert shadow.publication_id is None
+        assert shadow.publication_claimed_at is None
+        assert shadow.discord_message_id is None
+        assert shadow.discord_thread_id is None
+        assert shadow.published_chunks == 0
+        assert shadow.published_at is None
 
 
 def test_shadow_result_does_not_mutate_canonical_scan(

--- a/tests/test_opengrep.py
+++ b/tests/test_opengrep.py
@@ -14,6 +14,7 @@ from mainframe.endpoints.opengrep import (
     get_opengrep_rules,
     get_unpublished_opengrep_results,
     heartbeat_opengrep_publication,
+    queue_opengrep_alert,
     require_opengrep_shadow,
     submit_opengrep_result,
 )
@@ -47,6 +48,7 @@ def queued_shadow(db_session: Session) -> Scan:
         db_session.add(
             OpenGrepScan(
                 scan_id=scan.scan_id,
+                alerted_at=dt.datetime.now(dt.UTC),
                 queued_at=scan.queued_at or dt.datetime.now(dt.UTC),
                 queued_by=scan.queued_by,
             )
@@ -115,16 +117,13 @@ def test_opengrep_rules_are_separate() -> None:
     assert response.rules == {"python/payload.yml": "rules: []"}
 
 
-def test_queue_creates_additive_shadow_work_when_enabled(
+def test_package_ingestion_never_creates_shadow_work(
     db_session: Session,
     auth: AuthenticationData,
     pypi_client: PyPIClient,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("mainframe.constants.mainframe_settings.opengrep_shadow_enabled", True)
-
     response = queue_package(
-        PackageSpecifier(name="new-shadow-package", version="1.0.0"),
+        PackageSpecifier(name="ordinary-package", version="1.0.0"),
         db_session,
         auth,
         pypi_client,
@@ -135,8 +134,65 @@ def test_queue_creates_additive_shadow_work_when_enabled(
         shadow = db_session.get(OpenGrepScan, uuid.UUID(response.id))
         assert canonical is not None
         assert canonical.status == Status.QUEUED
+        assert shadow is None
+
+
+def test_alert_creates_idempotent_shadow_work(
+    db_session: Session,
+    auth: AuthenticationData,
+) -> None:
+    scan = Scan(
+        name="alerting-package",
+        version="1.0.0",
+        status=Status.FINISHED,
+        queued_by="scanner",
+        download_urls=[DownloadURL(url="https://files.example/alerting-package.whl")],
+    )
+    with db_session.begin():
+        db_session.add(scan)
+
+    package = PackageSpecifier(name=scan.name, version=scan.version)
+    first = queue_opengrep_alert(package, db_session, auth)
+    second = queue_opengrep_alert(package, db_session, auth)
+
+    assert first == second
+    with db_session.begin():
+        shadow = db_session.get(OpenGrepScan, scan.scan_id)
         assert shadow is not None
-        assert shadow.status == Status.QUEUED
+        assert shadow.alerted_at is not None
+        assert shadow.queued_by == auth.subject
+
+
+def test_pre_gate_shadow_work_stays_inert(
+    db_session: Session,
+    auth: AuthenticationData,
+    rules_state: Rules,
+) -> None:
+    scan = Scan(
+        name="legacy-shadow-package",
+        version="1.0.0",
+        status=Status.FINISHED,
+        queued_by="scanner",
+        download_urls=[DownloadURL(url="https://files.example/legacy-shadow-package.whl")],
+    )
+    with db_session.begin():
+        db_session.add(scan)
+        db_session.flush([scan])
+        db_session.add(
+            OpenGrepScan(
+                scan_id=scan.scan_id,
+                queued_at=dt.datetime.now(dt.UTC),
+                queued_by="legacy-ingestion",
+            )
+        )
+
+    with pytest.raises(HTTPException, match="inert pre-alert-gate"):
+        queue_opengrep_alert(
+            PackageSpecifier(name=scan.name, version=scan.version),
+            db_session,
+            auth,
+        )
+    assert get_opengrep_jobs(db_session, auth, rules_state) == []
 
 
 def test_shadow_result_does_not_mutate_canonical_scan(


### PR DESCRIPTION
## Summary

- stop creating OpenGrep shadow rows during ordinary package ingestion
- add an authenticated staging-only alert handoff endpoint
- mark alert-triggered rows explicitly and keep all pre-gate rows inert
- restrict leasing, dead-lettering, and publication to alert-triggered rows

## Safety properties

- ordinary `/package` and `/batch/package` ingestion never creates OpenGrep work
- the canonical YARA queue and scan rows remain unchanged
- the alert handoff is idempotent per canonical scan
- the nullable `alerted_at` migration leaves the initial all-package backlog
  preserved but ineligible for leasing or publication
- no credential, tenant, audience, account, or token value is added

## Validation

- 68 focused OpenGrep/authentication tests passed
- complete Alembic chain upgraded successfully on disposable PostgreSQL 16
- `ruff format --check .`
- `ruff check .`
- `ty check`
- full `prek-workspace run --all-files`, including `ripsecrets`
