### PR TITLE
Route OpenGrep results to alert threads

### DIFF
--- a/alembic/versions/a71dc40e9b82_add_opengrep_alert_message_id.py
+++ b/alembic/versions/a71dc40e9b82_add_opengrep_alert_message_id.py
@@ -1,0 +1,29 @@
+"""add OpenGrep alert message ID
+
+Revision ID: a71dc40e9b82
+Revises: 71e3c2a9f804
+Create Date: 2026-07-31 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "a71dc40e9b82"
+down_revision = "71e3c2a9f804"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Store the optional Discord alert used as an OpenGrep thread root."""
+    op.add_column(
+        "opengrep_scans",
+        sa.Column("discord_alert_message_id", sa.BigInteger(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove only the experimental Discord alert routing metadata."""
+    op.drop_column("opengrep_scans", "discord_alert_message_id")

--- a/src/mainframe/endpoints/opengrep.py
+++ b/src/mainframe/endpoints/opengrep.py
@@ -361,15 +361,27 @@ def checkpoint_opengrep_publication(
         )
         if shadow.published_at is not None:
             return
-        if progress.published_chunks < shadow.published_chunks:
+        if shadow.discord_message_id is not None and progress.discord_message_id not in (
+            None,
+            shadow.discord_message_id,
+        ):
+            raise HTTPException(status.HTTP_409_CONFLICT, "discord_message_id cannot change after it is recorded.")
+        replacing_thread = (
+            shadow.discord_thread_id is not None
+            and progress.discord_thread_id is not None
+            and shadow.discord_thread_id != progress.discord_thread_id
+        )
+        if replacing_thread and progress.published_chunks != 0:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "A replacement Discord thread must restart publication progress.",
+            )
+        if not replacing_thread and progress.published_chunks < shadow.published_chunks:
             raise HTTPException(status.HTTP_409_CONFLICT, "OpenGrep publication progress cannot move backwards.")
-        for field in ("discord_message_id", "discord_thread_id"):
-            existing = getattr(shadow, field)
-            incoming = getattr(progress, field)
-            if existing is not None and incoming not in (None, existing):
-                raise HTTPException(status.HTTP_409_CONFLICT, f"{field} cannot change after it is recorded.")
-            if incoming is not None:
-                setattr(shadow, field, incoming)
+        if progress.discord_message_id is not None:
+            shadow.discord_message_id = progress.discord_message_id
+        if progress.discord_thread_id is not None:
+            shadow.discord_thread_id = progress.discord_thread_id
         shadow.published_chunks = progress.published_chunks
         shadow.publication_claimed_at = dt.datetime.now(dt.UTC)
 

--- a/src/mainframe/endpoints/opengrep.py
+++ b/src/mainframe/endpoints/opengrep.py
@@ -16,13 +16,13 @@ from mainframe.models.orm import OpenGrepScan, Scan, Status
 from mainframe.models.schemas import (
     GetRules,
     JobResult,
+    OpenGrepAlert,
     OpenGrepPublicationClaim,
     OpenGrepPublicationProgress,
     OpenGrepPublished,
     OpenGrepResult,
     OpenGrepScanResult,
     OpenGrepScanResultFail,
-    PackageSpecifier,
     QueuePackageResponse,
 )
 from mainframe.rules import Rules
@@ -81,7 +81,7 @@ def dead_letter_expired_shadow_scans(
 
 @router.post("/alerts")
 def queue_opengrep_alert(
-    package: PackageSpecifier,
+    package: OpenGrepAlert,
     session: Database,
     auth: Authenticated,
 ) -> QueuePackageResponse:
@@ -106,6 +106,7 @@ def queue_opengrep_alert(
                 alerted_at=now,
                 queued_at=now,
                 queued_by=auth.subject,
+                discord_alert_message_id=package.discord_alert_message_id,
             )
             session.add(shadow)
         elif shadow.alerted_at is None:
@@ -127,10 +128,22 @@ def queue_opengrep_alert(
             shadow.findings = []
             shadow.publication_id = None
             shadow.publication_claimed_at = None
+            shadow.discord_alert_message_id = package.discord_alert_message_id
             shadow.discord_message_id = None
             shadow.discord_thread_id = None
             shadow.published_chunks = 0
             shadow.published_at = None
+
+        elif shadow.discord_alert_message_id is None:
+            shadow.discord_alert_message_id = package.discord_alert_message_id
+        elif (
+            package.discord_alert_message_id is not None
+            and shadow.discord_alert_message_id != package.discord_alert_message_id
+        ):
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "OpenGrep shadow work is already attached to another Discord alert.",
+            )
 
         return QueuePackageResponse(id=str(scan.scan_id))
 
@@ -311,6 +324,7 @@ def get_unpublished_opengrep_results(
                 fail_reason=shadow.fail_reason,
                 finished_at=shadow.finished_at,
                 publication_id=cast("uuid.UUID", shadow.publication_id),
+                discord_alert_message_id=shadow.discord_alert_message_id,
                 discord_message_id=shadow.discord_message_id,
                 discord_thread_id=shadow.discord_thread_id,
                 published_chunks=shadow.published_chunks,

--- a/src/mainframe/models/orm.py
+++ b/src/mainframe/models/orm.py
@@ -151,6 +151,7 @@ class OpenGrepScan(Base):
     findings: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, default_factory=list)
     publication_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), default=None)
     publication_claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    discord_alert_message_id: Mapped[int | None] = mapped_column(BigInteger, default=None)
     discord_message_id: Mapped[int | None] = mapped_column(BigInteger, default=None)
     discord_thread_id: Mapped[int | None] = mapped_column(BigInteger, default=None)
     published_chunks: Mapped[int] = mapped_column(default=0, server_default="0")

--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -310,6 +310,12 @@ class OpenGrepScanResultFail(PackageSpecifier):
     assignment_id: uuid.UUID
 
 
+class OpenGrepAlert(PackageSpecifier):
+    """An alert delivered to Discord and eligible for OpenGrep processing."""
+
+    discord_alert_message_id: int | None = Field(default=None, ge=1)
+
+
 class OpenGrepResult(BaseModel):
     """Completed OpenGrep shadow work awaiting bot publication."""
 
@@ -323,6 +329,7 @@ class OpenGrepResult(BaseModel):
     fail_reason: str | None
     finished_at: datetime.datetime
     publication_id: uuid.UUID
+    discord_alert_message_id: int | None
     discord_message_id: int | None
     discord_thread_id: int | None
     published_chunks: int = Field(ge=0)

--- a/tests/test_opengrep.py
+++ b/tests/test_opengrep.py
@@ -22,6 +22,7 @@ from mainframe.endpoints.package import queue_package
 from mainframe.json_web_token import AuthenticationData
 from mainframe.models.orm import DownloadURL, OpenGrepScan, Scan, Status
 from mainframe.models.schemas import (
+    OpenGrepAlert,
     OpenGrepFinding,
     OpenGrepPublicationClaim,
     OpenGrepPublicationProgress,
@@ -151,23 +152,36 @@ def test_alert_creates_idempotent_shadow_work(
     with db_session.begin():
         db_session.add(scan)
 
-    package = PackageSpecifier(name=scan.name, version=scan.version)
+    package = OpenGrepAlert(name=scan.name, version=scan.version, discord_alert_message_id=100)
     first = queue_opengrep_alert(package, db_session, auth)
     second = queue_opengrep_alert(package, db_session, auth)
 
+    with pytest.raises(HTTPException, match="already attached") as conflict:
+        queue_opengrep_alert(
+            package.model_copy(update={"discord_alert_message_id": 101}),
+            db_session,
+            auth,
+        )
+
     assert first == second
+    assert conflict.value.status_code == status.HTTP_409_CONFLICT
     with db_session.begin():
         shadow = db_session.get(OpenGrepScan, scan.scan_id)
         assert shadow is not None
         assert shadow.alerted_at is not None
         assert shadow.queued_by == auth.subject
+        assert shadow.discord_alert_message_id == 100
 
 
 def test_alert_requires_an_existing_finished_scan(
     db_session: Session,
     auth: AuthenticationData,
 ) -> None:
-    missing = PackageSpecifier(name="missing-alert-package", version="1.0.0")
+    missing = OpenGrepAlert(
+        name="missing-alert-package",
+        version="1.0.0",
+        discord_alert_message_id=100,
+    )
     with pytest.raises(HTTPException) as missing_error:
         queue_opengrep_alert(missing, db_session, auth)
     assert missing_error.value.status_code == status.HTTP_404_NOT_FOUND
@@ -184,7 +198,7 @@ def test_alert_requires_an_existing_finished_scan(
 
     with pytest.raises(HTTPException, match="requires a finished canonical scan") as unfinished_error:
         queue_opengrep_alert(
-            PackageSpecifier(name=unfinished.name, version=unfinished.version),
+            OpenGrepAlert(name=unfinished.name, version=unfinished.version, discord_alert_message_id=100),
             db_session,
             auth,
         )
@@ -229,7 +243,7 @@ def test_alert_reinitializes_only_its_pre_gate_shadow_row(
         )
 
     queue_opengrep_alert(
-        PackageSpecifier(name=scan.name, version=scan.version),
+        OpenGrepAlert(name=scan.name, version=scan.version, discord_alert_message_id=300),
         db_session,
         auth,
     )
@@ -252,6 +266,7 @@ def test_alert_reinitializes_only_its_pre_gate_shadow_row(
         assert shadow.findings == []
         assert shadow.publication_id is None
         assert shadow.publication_claimed_at is None
+        assert shadow.discord_alert_message_id == 300
         assert shadow.discord_message_id is None
         assert shadow.discord_thread_id is None
         assert shadow.published_chunks == 0

--- a/tests/test_opengrep.py
+++ b/tests/test_opengrep.py
@@ -553,6 +553,18 @@ def test_shadow_publication_progress_is_monotonic_and_resumable(
     with pytest.raises(HTTPException, match="discord_message_id cannot change"):
         checkpoint_opengrep_publication(scan_id, changed_message, db_session)
 
+    incomplete_replacement = progress.model_copy(update={"discord_thread_id": 300})
+    with pytest.raises(HTTPException, match="must restart publication progress"):
+        checkpoint_opengrep_publication(scan_id, incomplete_replacement, db_session)
+
+    replacement = incomplete_replacement.model_copy(update={"published_chunks": 0})
+    checkpoint_opengrep_publication(scan_id, replacement, db_session)
+    with db_session.begin():
+        shadow = db_session.get(OpenGrepScan, scan_id)
+        assert shadow is not None
+        assert shadow.discord_thread_id == 300
+        assert shadow.published_chunks == 0
+
 
 def test_shadow_publication_rejects_a_stale_claim(
     db_session: Session,

--- a/tests/test_opengrep.py
+++ b/tests/test_opengrep.py
@@ -152,9 +152,11 @@ def test_alert_creates_idempotent_shadow_work(
     with db_session.begin():
         db_session.add(scan)
 
-    package = OpenGrepAlert(name=scan.name, version=scan.version, discord_alert_message_id=100)
-    first = queue_opengrep_alert(package, db_session, auth)
+    legacy_package = OpenGrepAlert(name=scan.name, version=scan.version)
+    package = legacy_package.model_copy(update={"discord_alert_message_id": 100})
+    first = queue_opengrep_alert(legacy_package, db_session, auth)
     second = queue_opengrep_alert(package, db_session, auth)
+    third = queue_opengrep_alert(package, db_session, auth)
 
     with pytest.raises(HTTPException, match="already attached") as conflict:
         queue_opengrep_alert(
@@ -163,7 +165,7 @@ def test_alert_creates_idempotent_shadow_work(
             auth,
         )
 
-    assert first == second
+    assert first == second == third
     assert conflict.value.status_code == status.HTTP_409_CONFLICT
     with db_session.begin():
         shadow = db_session.get(OpenGrepScan, scan.scan_id)


### PR DESCRIPTION
## Summary

- persist the originating Discord alert message ID with OpenGrep shadow work
- expose that routing metadata without changing publication checkpoint semantics
- reject attempts to attach one scan to a different alert
- add a nullable, reversible Alembic migration

## Rollback safety

The field is additive and nullable. Old queue payloads remain valid, old bot
clients ignore the response field, and downgrade removes only experimental
Discord routing metadata. Upgrade, downgrade, and re-upgrade were exercised
against PostgreSQL 16.

## Validation

- `pytest` (236 passed)
- complete `prek-workspace run --all-files`
- migration upgrade → downgrade → re-upgrade
