### PR TITLE
Store partial OpenGrep scan results

### DIFF
--- a/src/mainframe/endpoints/opengrep.py
+++ b/src/mainframe/endpoints/opengrep.py
@@ -275,6 +275,7 @@ def submit_opengrep_result(
         shadow.status = Status.FINISHED
         shadow.commit_hash = result.commit
         shadow.findings = [finding.model_dump(mode="json") for finding in result.findings]
+        shadow.fail_reason = result.partial_reason
 
 
 @router.get("/results")

--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -292,11 +292,12 @@ class OpenGrepFinding(BaseModel):
 
 
 class OpenGrepScanResult(PackageSpecifier):
-    """Successful OpenGrep shadow result."""
+    """Complete or partial OpenGrep shadow result with preserved findings."""
 
     commit: Annotated[str, Field(min_length=1, max_length=128)]
     duration_ms: int = Field(ge=0)
     findings: list[OpenGrepFinding] = Field(max_length=500)
+    partial_reason: Annotated[str, Field(min_length=1, max_length=2048)] | None = None
     attempt: int = Field(ge=1)
     assignment_id: uuid.UUID
 

--- a/tests/test_opengrep.py
+++ b/tests/test_opengrep.py
@@ -305,6 +305,7 @@ def test_shadow_result_does_not_mutate_canonical_scan(
             commit=job.hash,
             duration_ms=42,
             findings=[finding],
+            partial_reason="One rule timed out; preserved completed findings.",
             attempt=job.attempt,
             assignment_id=job.assignment_id,
         ),
@@ -317,6 +318,7 @@ def test_shadow_result_does_not_mutate_canonical_scan(
     assert len(unpublished) == 1
     assert unpublished[0].scan_id == scan.scan_id
     assert unpublished[0].findings == [finding]
+    assert unpublished[0].fail_reason == "One rule timed out; preserved completed findings."
     with db_session.begin():
         canonical = db_session.get(Scan, scan.scan_id)
         shadow = db_session.get(OpenGrepScan, scan.scan_id)
@@ -327,6 +329,7 @@ def test_shadow_result_does_not_mutate_canonical_scan(
         assert shadow is not None
         assert shadow.status == Status.FINISHED
         assert shadow.duration_ms == 42
+        assert shadow.fail_reason == "One rule timed out; preserved completed findings."
 
     claim = OpenGrepPublicationClaim(publication_id=unpublished[0].publication_id)
     acknowledgement = acknowledge_opengrep_result(scan.scan_id, claim, db_session)


### PR DESCRIPTION
## Summary

- accept an optional bounded partial-result diagnostic with successful OpenGrep findings
- persist the diagnostic through the existing nullable reason field
- publish partial findings through the existing finished-result path

## Compatibility

This is migration-free. Older workers omit `partial_reason`; older stored rows remain unchanged. Complete and failed result payloads retain their current behavior.

## Validation

- `ruff check src tests`
- `ruff format --check src tests`
- `pyright`
- `pytest` against isolated PostgreSQL 16 (236 passed)
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
