### PR TITLE
Expose queue refresh interval in queue status endpoint

### DIFF
--- a/src/mainframe/models/schemas.py
+++ b/src/mainframe/models/schemas.py
@@ -31,6 +31,7 @@ class QueueStatus(BaseModel):
     oldest_queued_at: datetime.datetime | None
     oldest_age_seconds: int | None
     sampled_at: datetime.datetime
+    refresh_interval_seconds: int
 
     @field_serializer("oldest_queued_at", "sampled_at")
     def serialize_timestamp(self, value: datetime.datetime | None) -> int | None:

--- a/src/mainframe/queue_monitor.py
+++ b/src/mainframe/queue_monitor.py
@@ -21,6 +21,7 @@ def read_queue_status(
     now: dt.datetime,
     job_timeout: int,
     max_job_attempts: int,
+    refresh_interval_seconds: int,
 ) -> QueueStatus:
     """Read all queue states with one indexed aggregate query."""
     retry_before = now - dt.timedelta(seconds=job_timeout)
@@ -65,6 +66,7 @@ def read_queue_status(
         oldest_queued_at=oldest_queued_at,
         oldest_age_seconds=oldest_age_seconds,
         sampled_at=now,
+        refresh_interval_seconds=refresh_interval_seconds,
     )
 
 
@@ -85,10 +87,18 @@ def update_queue_metrics(snapshot: QueueStatus) -> None:
 class QueueMonitor:
     """Periodically refreshed, process-local view of durable database queue state."""
 
-    def __init__(self, engine: Engine, *, job_timeout: int, max_job_attempts: int) -> None:
+    def __init__(
+        self,
+        engine: Engine,
+        *,
+        job_timeout: int,
+        max_job_attempts: int,
+        refresh_interval_seconds: int,
+    ) -> None:
         self.engine = engine
         self.job_timeout = job_timeout
         self.max_job_attempts = max_job_attempts
+        self.refresh_interval_seconds = refresh_interval_seconds
         self._snapshot: QueueStatus | None = None
         self._lock = Lock()
 
@@ -100,6 +110,7 @@ class QueueMonitor:
                 now=sampled_at,
                 job_timeout=self.job_timeout,
                 max_job_attempts=self.max_job_attempts,
+                refresh_interval_seconds=self.refresh_interval_seconds,
             )
 
         update_queue_metrics(snapshot)

--- a/src/mainframe/server.py
+++ b/src/mainframe/server.py
@@ -106,6 +106,7 @@ async def lifespan(app_: FastAPI) -> AsyncGenerator[None, None]:
         engine,
         job_timeout=mainframe_settings.job_timeout,
         max_job_attempts=mainframe_settings.max_job_attempts,
+        refresh_interval_seconds=mainframe_settings.queue_metrics_refresh_seconds,
     )
     app_.state.queue_monitor = queue_monitor
     try:
@@ -114,7 +115,7 @@ async def lifespan(app_: FastAPI) -> AsyncGenerator[None, None]:
         packages_queue_refresh_failures.inc()
         logging.getLogger(__name__).exception("Failed to load initial queue metrics")
     queue_monitor_task = asyncio.create_task(
-        monitor_queue(queue_monitor, mainframe_settings.queue_metrics_refresh_seconds)
+        monitor_queue(queue_monitor, queue_monitor.refresh_interval_seconds)
     )
     performance_monitor = PerformanceMonitor(engine)
     app_.state.performance_monitor = performance_monitor

--- a/tests/test_queue_monitor.py
+++ b/tests/test_queue_monitor.py
@@ -73,7 +73,9 @@ def test_queue_status_distinguishes_durable_states(db_session: Session) -> None:
     )
 
     with db_session.begin():
-        snapshot = read_queue_status(db_session, now=now, job_timeout=120, max_job_attempts=3)
+        snapshot = read_queue_status(
+            db_session, now=now, job_timeout=120, max_job_attempts=3, refresh_interval_seconds=60
+        )
 
     assert snapshot.queued == 1
     assert snapshot.in_progress == 1
@@ -84,6 +86,7 @@ def test_queue_status_distinguishes_durable_states(db_session: Session) -> None:
     assert snapshot.oldest_queued_at == now - dt.timedelta(minutes=10)
     assert snapshot.oldest_age_seconds == 600
     assert snapshot.sampled_at == now
+    assert snapshot.refresh_interval_seconds == 60
 
 
 def test_queue_status_handles_an_empty_queue(db_session: Session) -> None:
@@ -91,7 +94,9 @@ def test_queue_status_handles_an_empty_queue(db_session: Session) -> None:
     replace_queue(db_session, [])
 
     with db_session.begin():
-        snapshot = read_queue_status(db_session, now=now, job_timeout=120, max_job_attempts=3)
+        snapshot = read_queue_status(
+            db_session, now=now, job_timeout=120, max_job_attempts=3, refresh_interval_seconds=60
+        )
 
     assert snapshot.total_backlog == 0
     assert snapshot.stranded == 0
@@ -105,7 +110,7 @@ def test_queue_status_normalizes_a_naive_database_timestamp() -> None:
     oldest_queued_at = (now - dt.timedelta(minutes=5)).replace(tzinfo=None)
     session.execute.return_value.one.return_value = (1, 0, 0, 0, 0, oldest_queued_at)
 
-    snapshot = read_queue_status(session, now=now, job_timeout=120, max_job_attempts=3)
+    snapshot = read_queue_status(session, now=now, job_timeout=120, max_job_attempts=3, refresh_interval_seconds=60)
 
     assert snapshot.oldest_queued_at == now - dt.timedelta(minutes=5)
     assert snapshot.oldest_age_seconds == 300
@@ -114,7 +119,7 @@ def test_queue_status_normalizes_a_naive_database_timestamp() -> None:
 def test_queue_monitor_caches_latest_snapshot(db_session: Session, engine: Engine) -> None:
     now = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
     replace_queue(db_session, [])
-    monitor = QueueMonitor(engine, job_timeout=120, max_job_attempts=3)
+    monitor = QueueMonitor(engine, job_timeout=120, max_job_attempts=3, refresh_interval_seconds=60)
 
     assert monitor.get_snapshot() is None
 
@@ -132,11 +137,12 @@ def test_queue_monitor_caches_latest_snapshot(db_session: Session, engine: Engin
         "oldest_queued_at": None,
         "oldest_age_seconds": None,
         "sampled_at": int(now.timestamp()),
+        "refresh_interval_seconds": 60,
     }
 
 
 def test_queue_endpoint_is_unavailable_before_initial_snapshot(engine: Engine) -> None:
-    monitor = QueueMonitor(engine, job_timeout=120, max_job_attempts=3)
+    monitor = QueueMonitor(engine, job_timeout=120, max_job_attempts=3, refresh_interval_seconds=60)
 
     with pytest.raises(HTTPException) as error:
         queue_status(monitor)


### PR DESCRIPTION
Add `refresh_interval_seconds` to the `QueueStatus` schema so consumers of the queue metrics endpoint can read how often the queue is sampled directly, instead of inferring it from successive `sampled_at` timestamps.

The queue monitor now owns its refresh interval (sourced from `queue_metrics_refresh_seconds`) and stamps it onto each snapshot, which the background refresh loop also reuses.

Closes #412